### PR TITLE
Keep error stack

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ class AbortError extends Error {
 		if (message instanceof Error) {
 			this.originalError = message;
 			({message} = message);
+			this.stack = message.stack;
 		} else {
 			this.originalError = new Error(message);
 			this.originalError.stack = this.stack;


### PR DESCRIPTION
Keep error stack when pass Error instance to AbortError