### PR TITLE
Add optional context to options

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,10 +47,10 @@ module.exports = (input, options) => new Promise((resolve, reject) => {
 				reject(error);
 			} else if (operation.retry(error)) {
 				decorateErrorWithCounts(error, attemptNumber, options);
-				options.onFailedAttempt(error);
+				options.onFailedAttempt(error, options.context);
 			} else {
 				decorateErrorWithCounts(error, attemptNumber, options);
-				options.onFailedAttempt(error);
+				options.onFailedAttempt(error, options.context);
 				reject(operation.mainError());
 			}
 		})

--- a/test.js
+++ b/test.js
@@ -152,3 +152,26 @@ test('onFailedAttempt is called before last rejection', async t => {
 		t.is(j, 4);
 	});
 });
+
+test('onFailedAttempt receives context when defined', async t => {
+	await pRetry(
+		async () => {
+			await delay(40);
+			return Promise.reject(fixtureErr);
+		},
+		{
+			onFailedAttempt: (err, con) => {
+				t.is(err, fixtureErr);
+				t.is(con.simulated, 'context');
+				t.is(con.fake, true);
+			},
+			context: {
+				simulated: 'context',
+				fake: true
+			},
+			retries: 2
+		}
+	).catch(error => {
+		t.is(error, fixtureErr);
+	});
+});


### PR DESCRIPTION
This PR should be correct, sorry for the confusion.

@sindresorhus I'm not sure if this is something you'd entertain including but I had the need to be able to reference a specific context (a class instance) from the onFailAttempt handler.  

Basically, I have a process that runs continually and makes a chain of API calls to a remote API that is secured with OAuth.  If any of the calls in the promise chain fail in a non-fatal manner I want to retry them using p-retry.  However, if a call fails with a 401 it could be because the OAuth token I was using expired.  In this case, I need to refresh the token and retry the call or it will continue failing until max retries is hit. 

To accomplish this I added the `context` option which, in my case, is a reference to my class instance (this).  In the `onFailAttempt` handler I basically do : 
```js
if(error.statusCode === 401 && error.reason === 'InvalidOAuthToken') {
    context.refreshOAuthToken();
}
```
Where `context` is the reference to my class instance and causes it to acquire a new OAuth token.

The changes were very simple and I'm hoping it's a helpful addition for others as well.  I've included a test case and update to the readme using a contrived example.

Let me know what you think, please.
