### PR TITLE
Allow `onFailedAttempt` to be async

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,17 @@ declare namespace pRetry {
 	interface Options extends OperationOptions {
 		/**
 		Callback invoked on each retry. Receives the error thrown by `input` as the first argument with properties `attemptNumber` and `retriesLeft` which indicate the current attempt number and the number of attempts left, respectively.
+
+		`onFailedAttempt` can return a promise to enable introducing a retry [delay](https://www.npmjs.com/package/delay):
+
+		```js
+		onFailedAttempt: async (error) => {
+			console.log('Waiting for 1 second before retrying');
+			await delay(1000);
+		},
+		```
+
+		If `onFailedAttempt` throws, all retries will be aborted and the original promise will reject with the thrown error.
 		*/
 		readonly onFailedAttempt?: (error: FailedAttemptError) => void;
 	}

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const pRetry = (input, options) => new Promise((resolve, reject) => {
 				reject(error);
 			} else {
 				decorateErrorWithCounts(error, attemptNumber, options);
-				options.onFailedAttempt(error);
+				await options.onFailedAttempt(error);
 
 				if (!operation.retry(error)) {
 					reject(operation.mainError());

--- a/index.js
+++ b/index.js
@@ -53,7 +53,12 @@ const pRetry = (input, options) => new Promise((resolve, reject) => {
 				reject(error);
 			} else {
 				decorateErrorWithCounts(error, attemptNumber, options);
-				await options.onFailedAttempt(error);
+
+				try {
+					await options.onFailedAttempt(error);
+				} catch (err) {
+					return reject(err);
+				}
 
 				if (!operation.retry(error)) {
 					reject(operation.mainError());

--- a/index.js
+++ b/index.js
@@ -56,8 +56,9 @@ const pRetry = (input, options) => new Promise((resolve, reject) => {
 
 				try {
 					await options.onFailedAttempt(error);
-				} catch (err) {
-					return reject(err);
+				} catch (error) {
+					reject(error);
+					return;
 				}
 
 				if (!operation.retry(error)) {

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,16 @@ const run = async () => {
 })();
 ```
 
+`onFailedAttempt` can return a promise to enable introducing a retry [delay](https://www.npmjs.com/package/delay):
+
+```js
+onFailedAttempt: async (error) => {
+	console.log('waiting for 1s before retrying');
+	await delay(1000)
+},
+```
+
+If `onFailedAttempt` throws, all retries will be aborted.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -66,8 +66,8 @@ const run = async () => {
 
 ```js
 onFailedAttempt: async (error) => {
-	console.log('waiting for 1s before retrying');
-	await delay(1000)
+	console.log('Waiting for 1 second before retrying');
+	await delay(1000);
 },
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -62,17 +62,6 @@ const run = async () => {
 })();
 ```
 
-`onFailedAttempt` can return a promise to enable introducing a retry [delay](https://www.npmjs.com/package/delay):
-
-```js
-onFailedAttempt: async (error) => {
-	console.log('Waiting for 1 second before retrying');
-	await delay(1000);
-},
-```
-
-If `onFailedAttempt` throws, all retries will be aborted.
-
 ## API
 
 ### pRetry(input, [options])
@@ -98,6 +87,17 @@ Options are passed to the [`retry`](https://github.com/tim-kos/node-retry#retryo
 Type: `Function`
 
 Callback invoked on each retry. Receives the error thrown by `input` as the first argument with properties `attemptNumber` and `retriesLeft` which indicate the current attempt number and the number of attempts left, respectively.
+
+`onFailedAttempt` can return a promise to enable introducing a retry [delay](https://www.npmjs.com/package/delay):
+
+```js
+onFailedAttempt: async (error) => {
+	console.log('Waiting for 1 second before retrying');
+	await delay(1000);
+},
+```
+
+If `onFailedAttempt` throws, all retries will be aborted and the original promise will reject with the thrown error.
 
 ### pRetry.AbortError(message|error)
 

--- a/test.js
+++ b/test.js
@@ -151,7 +151,7 @@ test('onFailedAttempt is called before last rejection', async t => {
 test('onFailedAttempt can return a promise to add a delay', async t => {
 	const waitFor = 1000;
 	const start = Date.now();
-	let called;
+	let isCalled;
 
 	await pRetry(
 		async () => {
@@ -161,7 +161,7 @@ test('onFailedAttempt can return a promise to add a delay', async t => {
 
 			called = true;
 
-			return Promise.reject(fixtureError);
+			throw fixtureError;
 		},
 		{
 			onFailedAttempt: async () => {

--- a/test.js
+++ b/test.js
@@ -155,11 +155,11 @@ test('onFailedAttempt can return a promise to add a delay', async t => {
 
 	await pRetry(
 		async () => {
-			if (called) {
+			if (isCalled) {
 				return fixture;
 			}
 
-			called = true;
+			isCalled = true;
 
 			throw fixtureError;
 		},
@@ -178,7 +178,9 @@ test('onFailedAttempt can throw, causing all retries to be aborted', async t => 
 	const error = new Error('thrown from onFailedAttempt');
 
 	try {
-		await pRetry(() => Promise.reject(fixtureError), {
+		await pRetry(async () => {
+			throw fixtureError;
+		}, {
 			onFailedAttempt: () => {
 				throw error;
 			}


### PR DESCRIPTION
Builds on #29 and adds tests & docs.  Also wraps the invocation of `onFailedAttempt` in a `try/catch` to avoid `unhandledPromiseRejection`s if it throws.

Fixes #27.