### PR TITLE
Support `cross-fetch` for retrying on network errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ const retry = require('retry');
 const networkErrorMsgs = [
 	'Failed to fetch', // Chrome
 	'NetworkError when attempting to fetch resource', // Firefox
-	'The Internet connection appears to be offline' // Safari
+	'The Internet connection appears to be offline', // Safari
+	'Network request failed' // cross-fetch
 ];
 
 class AbortError extends Error {


### PR DESCRIPTION
This PR...
- adds `Network request failed` to the list of `networkErrorMsgs` which is the error text emitted by the [cross-fetch](https://github.com/lquixada/cross-fetch) module

Fixes #43