### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	],
 	"dependencies": {
 		"@types/retry": "^0.12.0",
-		"retry": "^0.12.0"
+		"retry": "^0.13.1"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
`node-retry` package has been updated to version 0.13.1 with several patches

https://github.com/tim-kos/node-retry/releases/tag/v0.13.1