### PR TITLE
Fix retrying on network error in Firefox and Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const retry = require('retry');
 const networkErrorMsgs = [
 	'Failed to fetch', // Chrome
 	'NetworkError when attempting to fetch resource.', // Firefox
-	'The Internet connection appears to be offline', // Safari
+	'The Internet connection appears to be offline.', // Safari
 	'Network request failed' // `cross-fetch`
 ];
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const retry = require('retry');
 
 const networkErrorMsgs = [
 	'Failed to fetch', // Chrome
-	'NetworkError when attempting to fetch resource', // Firefox
+	'NetworkError when attempting to fetch resource.', // Firefox
 	'The Internet connection appears to be offline', // Safari
 	'Network request failed' // `cross-fetch`
 ];

--- a/test.js
+++ b/test.js
@@ -62,6 +62,20 @@ test('retry on TypeError - failed to fetch', async t => {
 	t.is(index, 3);
 });
 
+test('retry on TypeError - NetworkError when attempting to fetch resource.', async t => {
+	const typeErrorFixture = new TypeError('NetworkError when attempting to fetch resource.');
+	let index = 0;
+
+	const returnValue = await pRetry(async attemptNumber => {
+		await delay(40);
+		index++;
+		return attemptNumber === 3 ? fixture : Promise.reject(typeErrorFixture);
+	});
+
+	t.is(returnValue, fixture);
+	t.is(index, 3);
+});
+
 test('AbortError - string', t => {
 	const error = new pRetry.AbortError('fixture').originalError;
 	t.is(error.constructor.name, 'Error');

--- a/test.js
+++ b/test.js
@@ -76,6 +76,20 @@ test('retry on TypeError - NetworkError when attempting to fetch resource.', asy
 	t.is(index, 3);
 });
 
+test('retry on TypeError - The Internet connection appears to be offline.', async t => {
+	const typeErrorFixture = new TypeError('The Internet connection appears to be offline.');
+	let index = 0;
+
+	const returnValue = await pRetry(async attemptNumber => {
+		await delay(40);
+		index++;
+		return attemptNumber === 3 ? fixture : Promise.reject(typeErrorFixture);
+	});
+
+	t.is(returnValue, fixture);
+	t.is(index, 3);
+});
+
 test('AbortError - string', t => {
 	const error = new pRetry.AbortError('fixture').originalError;
 	t.is(error.constructor.name, 'Error');

--- a/test.js
+++ b/test.js
@@ -62,34 +62,6 @@ test('retry on TypeError - failed to fetch', async t => {
 	t.is(index, 3);
 });
 
-test('retry on TypeError - NetworkError when attempting to fetch resource.', async t => {
-	const typeErrorFixture = new TypeError('NetworkError when attempting to fetch resource.');
-	let index = 0;
-
-	const returnValue = await pRetry(async attemptNumber => {
-		await delay(40);
-		index++;
-		return attemptNumber === 3 ? fixture : Promise.reject(typeErrorFixture);
-	});
-
-	t.is(returnValue, fixture);
-	t.is(index, 3);
-});
-
-test('retry on TypeError - The Internet connection appears to be offline.', async t => {
-	const typeErrorFixture = new TypeError('The Internet connection appears to be offline.');
-	let index = 0;
-
-	const returnValue = await pRetry(async attemptNumber => {
-		await delay(40);
-		index++;
-		return attemptNumber === 3 ? fixture : Promise.reject(typeErrorFixture);
-	});
-
-	t.is(returnValue, fixture);
-	t.is(index, 3);
-});
-
 test('AbortError - string', t => {
 	const error = new pRetry.AbortError('fixture').originalError;
 	t.is(error.constructor.name, 'Error');


### PR DESCRIPTION
Fixes #51

Added missing dot(".") at the end of Firefox error message.