### PR TITLE
Update readme to explain how to import AbortError

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ npm install p-retry
 ## Usage
 
 ```js
-import pRetry from 'p-retry';
+import pRetry, { AbortError } from 'p-retry';
 import fetch from 'node-fetch';
 
 const run = async () => {
@@ -21,7 +21,7 @@ const run = async () => {
 
 	// Abort retrying if the resource doesn't exist
 	if (response.status === 404) {
-		throw new pRetry.AbortError(response.statusText);
+		throw new AbortError(response.statusText);
 	}
 
 	return response.blob();


### PR DESCRIPTION
Hey,

I found that since the switch to ESM, the README has a small error, which is corrected in this PR.  As `AbortError` is now a named export, so should be imported using curly brace syntax, instead of it being a property of the default export.