### PR TITLE
Handle Undici network errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const networkErrorMsgs = new Set([
 	'NetworkError when attempting to fetch resource.', // Firefox
 	'The Internet connection appears to be offline.', // Safari
 	'Network request failed', // `cross-fetch`
+	'fetch failed', // Undici (Node.js)
 ]);
 
 export class AbortError extends Error {


### PR DESCRIPTION
Another one… Undici, the native fetch implementation in Node.js >= 18, returns `TypeError('fetch failed')` on network errors:

https://github.com/nodejs/undici/blob/c4803cf5c963b8927d233b2256a0f6bb6fcd5d82/lib/fetch/index.js#L224-L231
