### PR TITLE
Rewrite the package to not depend on `retry`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 20
           - 18
-          - 16
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import {type OperationOptions} from 'retry';
-
 export class AbortError extends Error {
 	readonly name: 'AbortError';
 	readonly originalError: Error;
@@ -21,13 +19,41 @@ export type Options = {
 	/**
 	Callback invoked on each retry. Receives the error thrown by `input` as the first argument with properties `attemptNumber` and `retriesLeft` which indicate the current attempt number and the number of attempts left, respectively.
 
+	@example
+	```
+	import pRetry from 'p-retry';
+
+	const run = async () => {
+		const response = await fetch('https://sindresorhus.com/unicorn');
+
+		if (!response.ok) {
+			throw new Error(response.statusText);
+		}
+
+		return response.json();
+	};
+
+	const result = await pRetry(run, {
+		onFailedAttempt: error => {
+			console.log(`Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`);
+			// 1st request => Attempt 1 failed. There are 5 retries left.
+			// 2nd request => Attempt 2 failed. There are 4 retries left.
+			// …
+		},
+		retries: 5
+	});
+
+	console.log(result);
+	```
+
 	The `onFailedAttempt` function can return a promise. For example, to add a [delay](https://github.com/sindresorhus/delay):
 
+	@example
 	```
 	import pRetry from 'p-retry';
 	import delay from 'delay';
 
-	const run = async () => { ... };
+	const run = async () => { … };
 
 	const result = await pRetry(run, {
 		onFailedAttempt: async error => {
@@ -64,6 +90,48 @@ export type Options = {
 	readonly shouldRetry?: (error: FailedAttemptError) => boolean | Promise<boolean>;
 
 	/**
+	The maximum amount of times to retry the operation.
+
+	@default 10
+	*/
+	readonly retries?: number;
+
+	/**
+	The exponential factor to use.
+
+	@default 2
+	*/
+	readonly factor?: number;
+
+	/**
+	The number of milliseconds before starting the first retry.
+
+	@default 1000
+	*/
+	readonly minTimeout?: number;
+
+	/**
+	The maximum number of milliseconds between two retries.
+
+	@default Infinity
+	*/
+	readonly maxTimeout?: number;
+
+	/**
+	Randomizes the timeouts by multiplying with a factor between 1 and 2.
+
+	@default false
+	*/
+	readonly randomize?: boolean;
+
+	/**
+	The maximum time (in milliseconds) that the retried operation is allowed to run.
+
+	@default Infinity
+	*/
+	readonly maxRetryTime?: number;
+
+	/**
 	You can abort retrying using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
 
 	```
@@ -85,16 +153,24 @@ export type Options = {
 	```
 	*/
 	readonly signal?: AbortSignal;
-} & OperationOptions;
+
+	/**
+	Prevents retry timeouts from keeping the process alive.
+
+	Only affects platforms with a `.unref()` method on timeouts, such as Node.js.
+
+	@default false
+	*/
+	readonly unref?: boolean;
+};
 
 /**
 Returns a `Promise` that is fulfilled when calling `input` returns a fulfilled promise. If calling `input` returns a rejected promise, `input` is called again until the max retries are reached, it then rejects with the last rejection reason.
 
-Does not retry on most `TypeErrors`, with the exception of network errors. This is done on a best case basis as different browsers have different [messages](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Checking_that_the_fetch_was_successful) to indicate this.
-See [whatwg/fetch#526 (comment)](https://github.com/whatwg/fetch/issues/526#issuecomment-554604080)
+Does not retry on most `TypeErrors`, with the exception of network errors. This is done on a best case basis as different browsers have different [messages](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Checking_that_the_fetch_was_successful) to indicate this. See [whatwg/fetch#526 (comment)](https://github.com/whatwg/fetch/issues/526#issuecomment-554604080)
 
 @param input - Receives the number of attempts as the first argument and is expected to return a `Promise` or any value.
-@param options - Options are passed to the [`retry`](https://github.com/tim-kos/node-retry#retryoperationoptions) module.
+@param options - Options for configuring the retry behavior.
 
 @example
 ```
@@ -113,19 +189,6 @@ const run = async () => {
 };
 
 console.log(await pRetry(run, {retries: 5}));
-
-// With the `onFailedAttempt` option:
-const result = await pRetry(run, {
-	onFailedAttempt: error => {
-		console.log(`Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`);
-		// 1st request => Attempt 1 failed. There are 4 retries left.
-		// 2nd request => Attempt 2 failed. There are 3 retries left.
-		// …
-	},
-	retries: 5
-});
-
-console.log(result);
 ```
 */
 export default function pRetry<T>(

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-import retry from 'retry';
 import isNetworkError from 'is-network-error';
 
 export class AbortError extends Error {
@@ -27,68 +26,101 @@ const decorateErrorWithCounts = (error, attemptNumber, options) => {
 	return error;
 };
 
-export default async function pRetry(input, options) {
-	return new Promise((resolve, reject) => {
-		options = {
-			onFailedAttempt() {},
-			retries: 10,
-			shouldRetry: () => true,
-			...options,
-		};
+function calculateDelay(attempt, options) {
+	const random = options.randomize ? (Math.random() + 1) : 1;
 
-		const operation = retry.operation(options);
+	let timeout = Math.round(random * Math.max(options.minTimeout, 1) * (options.factor ** (attempt - 1)));
+	timeout = Math.min(timeout, options.maxTimeout);
 
-		const abortHandler = () => {
-			operation.stop();
-			reject(options.signal?.reason);
-		};
+	return timeout;
+}
 
-		if (options.signal && !options.signal.aborted) {
-			options.signal.addEventListener('abort', abortHandler, {once: true});
-		}
+export default async function pRetry(input, options = {}) {
+	options = {
+		retries: 10,
+		factor: 2,
+		minTimeout: 1000,
+		maxTimeout: Number.POSITIVE_INFINITY,
+		randomize: false,
+		onFailedAttempt() {},
+		shouldRetry: () => true,
+		...options,
+	};
 
-		const cleanUp = () => {
-			options.signal?.removeEventListener('abort', abortHandler);
-			operation.stop();
-		};
+	options.signal?.throwIfAborted();
 
-		operation.attempt(async attemptNumber => {
-			try {
-				const result = await input(attemptNumber);
-				cleanUp();
-				resolve(result);
-			} catch (error) {
-				try {
-					if (!(error instanceof Error)) {
-						throw new TypeError(`Non-error was thrown: "${error}". You should only throw errors.`);
-					}
+	let attemptNumber = 0;
+	const startTime = Date.now();
 
-					if (error instanceof AbortError) {
-						throw error.originalError;
-					}
+	const maxRetryTime = options.maxRetryTime ?? Number.POSITIVE_INFINITY;
 
-					if (error instanceof TypeError && !isNetworkError(error)) {
-						throw error;
-					}
+	while (attemptNumber < options.retries + 1) {
+		attemptNumber++;
 
-					decorateErrorWithCounts(error, attemptNumber, options);
+		try {
+			options.signal?.throwIfAborted();
 
-					if (!(await options.shouldRetry(error))) {
-						operation.stop();
-						reject(error);
-					}
+			const result = await input(attemptNumber);
 
-					await options.onFailedAttempt(error);
+			options.signal?.throwIfAborted();
 
-					if (!operation.retry(error)) {
-						throw operation.mainError();
-					}
-				} catch (finalError) {
-					decorateErrorWithCounts(finalError, attemptNumber, options);
-					cleanUp();
-					reject(finalError);
-				}
+			return result;
+		} catch (catchError) {
+			let error = catchError;
+
+			if (!(error instanceof Error)) {
+				error = new TypeError(`Non-error was thrown: "${error}". You should only throw errors.`);
 			}
-		});
-	});
+
+			if (error instanceof AbortError) {
+				throw error.originalError;
+			}
+
+			if (error instanceof TypeError && !isNetworkError(error)) {
+				throw error;
+			}
+
+			decorateErrorWithCounts(error, attemptNumber, options);
+
+			// Always call onFailedAttempt
+			await options.onFailedAttempt(error);
+
+			const currentTime = Date.now();
+			if (
+				currentTime - startTime >= maxRetryTime
+				|| attemptNumber >= options.retries + 1
+				|| !(await options.shouldRetry(error))
+			) {
+				throw error; // Do not retry, throw the original error
+			}
+
+			// Calculate delay before next attempt
+			const delayTime = calculateDelay(attemptNumber, options);
+
+			// Ensure that delay does not exceed maxRetryTime
+			const timeLeft = maxRetryTime - (currentTime - startTime);
+			if (timeLeft <= 0) {
+				throw error; // Max retry time exceeded
+			}
+
+			const finalDelay = Math.min(delayTime, timeLeft);
+
+			// Introduce delay
+			if (finalDelay > 0) {
+				await new Promise((resolve, reject) => {
+					const timeoutToken = setTimeout(resolve, finalDelay);
+
+					options.signal?.addEventListener('abort', () => {
+						clearTimeout(timeoutToken);
+						reject(options.signal.reason);
+					}, {once: true});
+				});
+			}
+
+			options.signal?.throwIfAborted();
+		}
+	}
+
+	// Should not reach here, but in case it does, throw an error
+	throw new Error('Retry attempts exhausted without throwing an error.');
 }

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ const decorateErrorWithCounts = (error, attemptNumber, options) => {
 };
 
 function calculateDelay(attempt, options) {
+	const random = options.randomize ? (Math.random() + 1) : 1;
+
 	let timeout = Math.round(random * Math.max(options.minTimeout, 1) * (options.factor ** (attempt - 1)));
 	timeout = Math.min(timeout, options.maxTimeout);
 

--- a/index.js
+++ b/index.js
@@ -36,16 +36,14 @@ function calculateDelay(attempt, options) {
 }
 
 export default async function pRetry(input, options = {}) {
-	options = {
-		retries: 10,
-		factor: 2,
-		minTimeout: 1000,
-		maxTimeout: Number.POSITIVE_INFINITY,
-		randomize: false,
-		onFailedAttempt() {},
-		shouldRetry: () => true,
-		...options,
-	};
+	options = {...options};
+	options.retries ??= 10;
+	options.factor ??= 2;
+	options.minTimeout ??= 1000;
+	options.maxTimeout ??= Number.POSITIVE_INFINITY;
+	options.randomize ??= false;
+	options.onFailedAttempt ??= () => {};
+	options.shouldRetry ??= () => true;
 
 	options.signal?.throwIfAborted();
 

--- a/package.json
+++ b/package.json
@@ -44,14 +44,17 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"@types/retry": "0.12.2",
-		"is-network-error": "^1.0.0",
-		"retry": "^0.13.1"
+		"is-network-error": "^1.0.0"
 	},
 	"devDependencies": {
 		"ava": "^5.3.1",
 		"delay": "^6.0.0",
 		"tsd": "^0.28.1",
 		"xo": "^0.56.0"
+	},
+	"xo": {
+		"rules": {
+			"no-await-in-loop": "off"
+		}
 	}
 }

--- a/test.js
+++ b/test.js
@@ -18,25 +18,39 @@ test('retries', async t => {
 	t.is(index, 3);
 });
 
-test('aborts', async t => {
-	t.plan(2);
+test('retries forever when specified', async t => {
+	let attempts = 0;
+	const maxAttempts = 15; // Limit for test purposes
 
-	let index = 0;
+	await t.throwsAsync(pRetry(
+		async () => {
+			attempts++;
+			if (attempts === maxAttempts) {
+				throw new AbortError('stop');
+			}
 
-	await t.throwsAsync(pRetry(async attemptNumber => {
-		await delay(40);
-		index++;
-		return attemptNumber === 3 ? Promise.reject(new AbortError(fixtureError)) : Promise.reject(fixtureError);
-	}), {is: fixtureError});
+			throw new Error('test');
+		},
+		{
+			retries: Number.POSITIVE_INFINITY,
+			minTimeout: 0, // Speed up test
+		},
+	));
 
-	t.is(index, 3);
+	t.is(attempts, maxAttempts);
+});
+
+// Error Handling Tests
+test('throws useful error message when non-error is thrown', async t => {
+	await t.throwsAsync(pRetry(() => {
+		throw 'foo'; // eslint-disable-line no-throw-literal
+	}), {
+		message: /Non-error/,
+	});
 });
 
 test('no retry on TypeError', async t => {
-	t.plan(2);
-
 	const typeErrorFixture = new TypeError('type-error-fixture');
-
 	let index = 0;
 
 	await t.throwsAsync(pRetry(async attemptNumber => {
@@ -62,6 +76,29 @@ test('retry on TypeError - failed to fetch', async t => {
 	t.is(index, 3);
 });
 
+test('errors are preserved when maxRetryTime exceeded', async t => {
+	const originalError = new Error('original error');
+	const maxRetryTime = 100;
+	let startTime;
+
+	const error = await t.throwsAsync(pRetry(
+		async () => {
+			if (!startTime) {
+				startTime = Date.now();
+			}
+
+			await delay(maxRetryTime + 50); // Ensure we exceed maxRetryTime
+			throw originalError;
+		},
+		{
+			maxRetryTime,
+			minTimeout: 0,
+		},
+	));
+
+	t.is(error, originalError);
+});
+
 test('AbortError - string', t => {
 	const error = new AbortError('fixture').originalError;
 	t.is(error.constructor.name, 'Error');
@@ -74,191 +111,40 @@ test('AbortError - error', t => {
 	t.is(error.message, 'fixture');
 });
 
-test('onFailedAttempt is called expected number of times', async t => {
-	t.plan(8);
-
-	const retries = 5;
+test('aborts', async t => {
 	let index = 0;
-	let attemptNumber = 0;
 
-	await pRetry(
-		async attemptNumber => {
-			await delay(40);
-			index++;
-			return attemptNumber === 3 ? fixture : Promise.reject(fixtureError);
-		},
-		{
-			onFailedAttempt(error) {
-				t.is(error, fixtureError);
-				t.is(error.attemptNumber, ++attemptNumber);
-
-				switch (index) {
-					case 1: {
-						t.is(error.retriesLeft, retries);
-						break;
-					}
-
-					case 2: {
-						t.is(error.retriesLeft, 4);
-						break;
-					}
-
-					case 3: {
-						t.is(error.retriesLeft, 3);
-						break;
-					}
-
-					case 4: {
-						t.is(error.retriesLeft, 2);
-						break;
-					}
-
-					default: {
-						t.fail('onFailedAttempt was called more than 4 times');
-						break;
-					}
-				}
-			},
-			retries,
-		},
-	);
+	await t.throwsAsync(pRetry(async attemptNumber => {
+		await delay(40);
+		index++;
+		return attemptNumber === 3 ? Promise.reject(new AbortError(fixtureError)) : Promise.reject(fixtureError);
+	}), {is: fixtureError});
 
 	t.is(index, 3);
-	t.is(attemptNumber, 2);
 });
 
-test('onFailedAttempt is called before last rejection', async t => {
-	t.plan(15);
-
-	const r = 3;
-	let i = 0;
-	let j = 0;
+test('operation stops immediately on AbortError', async t => {
+	let attempts = 0;
 
 	await t.throwsAsync(pRetry(
 		async () => {
-			await delay(40);
-			i++;
-			throw fixtureError;
-		},
-		{
-			onFailedAttempt(error) {
-				t.is(error, fixtureError);
-				t.is(error.attemptNumber, ++j);
-
-				switch (i) {
-					case 1: {
-						t.is(error.retriesLeft, r);
-						break;
-					}
-
-					case 2: {
-						t.is(error.retriesLeft, 2);
-						break;
-					}
-
-					case 3: {
-						t.is(error.retriesLeft, 1);
-						break;
-					}
-
-					case 4: {
-						t.is(error.retriesLeft, 0);
-						break;
-					}
-
-					default: {
-						t.fail('onFailedAttempt was called more than 4 times');
-						break;
-					}
-				}
-			},
-			retries: r,
-		},
-	), {is: fixtureError});
-
-	t.is(i, 4);
-	t.is(j, 4);
-});
-
-test('onFailedAttempt can return a promise to add a delay', async t => {
-	const waitFor = 1000;
-	const start = Date.now();
-	let isCalled;
-
-	await pRetry(
-		async () => {
-			if (isCalled) {
-				return fixture;
+			attempts++;
+			if (attempts === 2) {
+				throw new AbortError('stop');
 			}
 
-			isCalled = true;
-
-			throw fixtureError;
+			throw new Error('test');
 		},
 		{
-			async onFailedAttempt() {
-				await delay(waitFor);
-			},
+			retries: 10,
+			minTimeout: 0,
 		},
-	);
+	));
 
-	t.true(Date.now() > start + waitFor);
-});
-
-test('onFailedAttempt can throw, causing all retries to be aborted', async t => {
-	t.plan(1);
-	const error = new Error('thrown from onFailedAttempt');
-
-	try {
-		await pRetry(async () => {
-			throw fixtureError;
-		}, {
-			onFailedAttempt() {
-				throw error;
-			},
-		});
-	} catch (error_) {
-		t.is(error_, error);
-	}
-});
-
-test('onFailedAttempt can be undefined', async t => {
-	const error = new Error('thrown from onFailedAttempt');
-
-	await t.throwsAsync(pRetry(() => {
-		throw error;
-	}, {
-		onFailedAttempt: undefined,
-		retries: 1,
-	}), {
-		is: error,
-	});
-});
-
-test('shouldRetry can be undefined', async t => {
-	const error = new Error('thrown from onFailedAttempt');
-
-	await t.throwsAsync(pRetry(() => {
-		throw error;
-	}, {
-		shouldRetry: undefined,
-		retries: 1,
-	}), {
-		is: error,
-	});
-});
-
-test('throws useful error message when non-error is thrown', async t => {
-	await t.throwsAsync(pRetry(() => {
-		throw 'foo'; // eslint-disable-line no-throw-literal
-	}), {
-		message: /Non-error/,
-	});
+	t.is(attempts, 2); // Should stop after AbortError
 });
 
 test('aborts with an AbortSignal', async t => {
-	t.plan(2);
-
 	let index = 0;
 	const controller = new AbortController();
 
@@ -273,16 +159,13 @@ test('aborts with an AbortSignal', async t => {
 	}, {
 		signal: controller.signal,
 	}), {
-		// TODO: Make this only `instanceOf: DOMException` when targeting Node.js 18.
-		instanceOf: globalThis.DOMException === undefined ? Error : DOMException,
+		instanceOf: DOMException,
 	});
 
 	t.is(index, 3);
 });
 
 test('preserves the abort reason', async t => {
-	t.plan(2);
-
 	let index = 0;
 	const controller = new AbortController();
 
@@ -304,12 +187,9 @@ test('preserves the abort reason', async t => {
 	t.is(index, 3);
 });
 
-test('should retry only when shouldRetry returns true', async t => {
-	t.plan(2);
-
+test('shouldRetry controls retry behavior', async t => {
 	const shouldRetryError = new Error('should-retry');
 	const customError = new Error('custom-error');
-
 	let index = 0;
 
 	await t.throwsAsync(pRetry(async () => {
@@ -327,4 +207,396 @@ test('should retry only when shouldRetry returns true', async t => {
 	});
 
 	t.is(index, 3);
+});
+
+test('handles async shouldRetry with maxRetryTime', async t => {
+	let attempts = 0;
+	const start = Date.now();
+	const maxRetryTime = 1000;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			attempts++;
+			throw new Error('test');
+		},
+		{
+			retries: 10,
+			maxRetryTime,
+			async shouldRetry() {
+				await delay(100);
+				return true;
+			},
+		},
+	));
+
+	t.true(Date.now() - start <= maxRetryTime + 200);
+	t.true(attempts < 10);
+});
+
+test('onFailedAttempt provides correct error details', async t => {
+	const retries = 5;
+	let index = 0;
+	let attemptNumber = 0;
+
+	await pRetry(
+		async attemptNumber => {
+			await delay(40);
+			index++;
+			return attemptNumber === 3 ? fixture : Promise.reject(fixtureError);
+		},
+		{
+			onFailedAttempt(error) {
+				t.is(error, fixtureError);
+				t.is(error.attemptNumber, ++attemptNumber);
+				t.is(error.retriesLeft, retries - (index - 1));
+			},
+			retries,
+		},
+	);
+
+	t.is(index, 3);
+	t.is(attemptNumber, 2);
+});
+
+test('onFailedAttempt can return a promise to add a delay', async t => {
+	const waitFor = 1000;
+	const start = Date.now();
+	let isCalled;
+
+	await pRetry(
+		async () => {
+			if (isCalled) {
+				return fixture;
+			}
+
+			isCalled = true;
+			throw fixtureError;
+		},
+		{
+			async onFailedAttempt() {
+				await delay(waitFor);
+			},
+		},
+	);
+
+	t.true(Date.now() > start + waitFor);
+});
+
+test('onFailedAttempt can throw to abort retries', async t => {
+	const error = new Error('thrown from onFailedAttempt');
+
+	await t.throwsAsync(pRetry(async () => {
+		throw fixtureError;
+	}, {
+		onFailedAttempt() {
+			throw error;
+		},
+	}), {
+		is: error,
+	});
+});
+
+test('factor affects exponential backoff', async t => {
+	const delays = [];
+	const factor = 2;
+	const minTimeout = 100;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			const attemptNumber = delays.length + 1;
+			const expectedDelay = minTimeout * (factor ** (attemptNumber - 1));
+			delays.push(expectedDelay);
+			throw new Error('test');
+		},
+		{
+			retries: 3,
+			factor,
+			minTimeout,
+			maxTimeout: Number.POSITIVE_INFINITY,
+			randomize: false,
+		},
+	));
+
+	t.is(delays[0], minTimeout);
+	t.is(delays[1], minTimeout * factor);
+	t.is(delays[2], minTimeout * (factor ** 2));
+});
+
+test('timeouts are incremental with factor', async t => {
+	const delays = [];
+	const minTimeout = 100;
+	const factor = 0.5; // Test with factor less than 1
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			const attemptNumber = delays.length + 1;
+			const expectedDelay = minTimeout * (factor ** (attemptNumber - 1));
+			delays.push(expectedDelay);
+			throw new Error('test');
+		},
+		{
+			retries: 3,
+			factor,
+			minTimeout,
+			maxTimeout: Number.POSITIVE_INFINITY,
+			randomize: false,
+		},
+	));
+
+	// Each delay should be factor times the previous
+	for (let i = 1; i < delays.length; i++) {
+		t.is(delays[i] / delays[i - 1], factor);
+	}
+});
+
+test('minTimeout is respected even with small factor', async t => {
+	const delays = [];
+	const minTimeout = 100;
+	const factor = 0.1; // Very small factor
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			const attemptNumber = delays.length + 1;
+			const expectedDelay = Math.max(minTimeout, minTimeout * (factor ** (attemptNumber - 1)));
+			delays.push(expectedDelay);
+			throw new Error('test');
+		},
+		{
+			retries: 3,
+			factor,
+			minTimeout,
+			maxTimeout: Number.POSITIVE_INFINITY,
+			randomize: false,
+		},
+	));
+
+	// All delays should be at least minTimeout
+	for (const delay of delays) {
+		t.true(delay >= minTimeout);
+	}
+});
+
+test('maxTimeout caps retry delays', async t => {
+	const delays = [];
+	const maxTimeout = 150;
+	const factor = 3;
+	const minTimeout = 100;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			const attemptNumber = delays.length + 1;
+			const expectedDelay = Math.min(
+				minTimeout * (factor ** (attemptNumber - 1)),
+				maxTimeout,
+			);
+			delays.push(expectedDelay);
+			throw new Error('test');
+		},
+		{
+			retries: 3,
+			minTimeout,
+			factor,
+			maxTimeout,
+			randomize: false,
+		},
+	));
+
+	t.is(delays[0], minTimeout);
+	t.is(delays[1], maxTimeout);
+	t.is(delays[2], maxTimeout);
+});
+
+test('randomize affects retry delays', async t => {
+	const delays = new Set();
+	const minTimeout = 100;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			const random = Math.random() + 1;
+			const delay = Math.round(random * minTimeout);
+			delays.add(delay);
+			throw new Error('test');
+		},
+		{
+			retries: 3,
+			minTimeout,
+			factor: 1,
+			randomize: true,
+		},
+	));
+
+	t.true(delays.size > 1);
+	for (const delay of delays) {
+		t.true(delay >= minTimeout);
+		t.true(delay <= minTimeout * 2);
+	}
+});
+
+test('maxRetryTime limits total retry duration', async t => {
+	const start = Date.now();
+	const maxRetryTime = 1000;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			await delay(400);
+			throw new Error('test');
+		},
+		{
+			retries: 10,
+			minTimeout: 100,
+			maxRetryTime,
+		},
+	));
+
+	t.true(Date.now() - start < maxRetryTime + 1000);
+});
+
+test('aborts immediately if signal is already aborted', async t => {
+	const controller = new AbortController();
+	controller.abort();
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			throw new Error('test');
+		},
+		{signal: controller.signal},
+	), {
+		instanceOf: DOMException,
+	});
+});
+
+test('throws on negative retry count', async t => {
+	await t.throwsAsync(
+		pRetry(
+			async () => {},
+			{retries: -1},
+		),
+		{
+			instanceOf: TypeError,
+			message: 'Expected `retries` to be a non-negative number.',
+		},
+	);
+});
+
+test('handles zero retries', async t => {
+	let attempts = 0;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			attempts++;
+			throw new Error('test');
+		},
+		{retries: 0},
+	));
+
+	t.is(attempts, 1); // Should only try once with zero retries
+});
+
+test('handles zero maxRetryTime', async t => {
+	let attempts = 0;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			attempts++;
+			throw new Error('test');
+		},
+		{maxRetryTime: 0},
+	));
+
+	t.is(attempts, 1); // Should only try once with zero maxRetryTime
+});
+
+test('handles invalid factor values', async t => {
+	const delays = [];
+	const minTimeout = 100;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			const expectedDelay = minTimeout; // Should default to minTimeout
+			delays.push(expectedDelay);
+			throw new Error('test');
+		},
+		{
+			retries: 2,
+			factor: 0, // Invalid factor
+			minTimeout,
+			randomize: false,
+		},
+	));
+
+	t.is(delays[0], minTimeout);
+	t.is(delays[1], minTimeout);
+});
+
+test('handles synchronous input function', async t => {
+	let attempts = 0;
+
+	await t.throwsAsync(pRetry(
+		() => { // Non-async function
+			attempts++;
+			throw new Error('test');
+		},
+		{retries: 2, minTimeout: 0},
+	));
+
+	t.is(attempts, 3); // Initial + 2 retries
+});
+
+test('aborts retries if input function returns null', async t => {
+	let attempts = 0;
+
+	const result = await pRetry(
+		() => {
+			attempts++;
+			return null;
+		},
+		{retries: 2},
+	);
+
+	t.is(attempts, 1); // Should stop after first success
+	t.is(result, null);
+});
+
+test('handles non-Error rejection values', async t => {
+	await t.throwsAsync(pRetry(
+		() => Promise.reject('string rejection'), // eslint-disable-line prefer-promise-reject-errors
+		{retries: 1, minTimeout: 0},
+	), {
+		message: /Non-error was thrown/,
+	});
+});
+
+test.serial('unref option prevents timeout from keeping process alive', async t => {
+	const delays = [];
+	let timeoutUnrefCalled = false;
+
+	// Mock setTimeout to track unref calls
+	const originalSetTimeout = setTimeout;
+	globalThis.setTimeout = (fn, ms) => {
+		const timeout = originalSetTimeout(fn, ms);
+		timeout.unref = () => {
+			timeoutUnrefCalled = true;
+			return timeout;
+		};
+
+		return timeout;
+	};
+
+	t.teardown(() => {
+		globalThis.setTimeout = originalSetTimeout;
+	});
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			delays.push(Date.now());
+			throw new Error('test');
+		},
+		{
+			retries: 2,
+			minTimeout: 50,
+			unref: true,
+		},
+	));
+
+	t.true(timeoutUnrefCalled, 'timeout.unref() should be called when unref option is true');
 });

--- a/test.js
+++ b/test.js
@@ -222,6 +222,32 @@ test('onFailedAttempt can throw, causing all retries to be aborted', async t => 
 	}
 });
 
+test('onFailedAttempt can be undefined', async t => {
+	const error = new Error('thrown from onFailedAttempt');
+
+	await t.throwsAsync(pRetry(() => {
+		throw error;
+	}, {
+		onFailedAttempt: undefined,
+		retries: 1,
+	}), {
+		is: error,
+	});
+});
+
+test('shouldRetry can be undefined', async t => {
+	const error = new Error('thrown from onFailedAttempt');
+
+	await t.throwsAsync(pRetry(() => {
+		throw error;
+	}, {
+		shouldRetry: undefined,
+		retries: 1,
+	}), {
+		is: error,
+	});
+});
+
 test('throws useful error message when non-error is thrown', async t => {
 	await t.throwsAsync(pRetry(() => {
 		throw 'foo'; // eslint-disable-line no-throw-literal


### PR DESCRIPTION
I'm not totally confident in the code yet and there are remaining things to do:

- [ ] Add the options to the types and readme
- [ ] Add more tests
- [ ] Add test to ensure it preserves callstack
- [ ] Ensure all functionality is handled
- [ ] Update readme