### PR TITLE
Don't error when trying to extend non-extensible errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,13 @@ const decorateErrorWithCounts = (error, attemptNumber, options) => {
 	// Minus 1 from attemptNumber because the first attempt does not count as a retry
 	const retriesLeft = options.retries - (attemptNumber - 1);
 
-	error.attemptNumber = attemptNumber;
-	error.retriesLeft = retriesLeft;
+	try {
+		error.attemptNumber = attemptNumber;
+		error.retriesLeft = retriesLeft;
+	} catch {
+		// ignore errors trying to extend non-extensible errors
+	}
+
 	return error;
 };
 

--- a/test.js
+++ b/test.js
@@ -328,3 +328,17 @@ test('should retry only when shouldRetry returns true', async t => {
 
 	t.is(index, 3);
 });
+
+test('can retry functions that throw non-extensible errors', async t => {
+	let index = 0;
+	const nonExtensibleError = Object.preventExtensions(new Error('non-extensible-error'));
+
+	const returnValue = await pRetry(async attemptNumber => {
+		await delay(40);
+		index++;
+		return attemptNumber === 3 ? fixture : Promise.reject(nonExtensibleError);
+	});
+
+	t.is(returnValue, fixture);
+	t.is(index, 3);
+});


### PR DESCRIPTION
Before this change, `pRetry` blindly tries to modify the error thrown by the inner function. If that error happens to not be an extensible object, this modification itself throws, which aborts the retry chain and obscures the inner error. This change makes `pRetry` not add these properties if the error object can't be extended under the presumption that retrying this error is better than hard erroring the first time its thrown.

Fixes #25