### PR TITLE
Clarify `shouldRetry` documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,8 @@ export type Options = {
 	/**
 	Decide if a retry should occur based on the context. Returning true triggers a retry, false aborts with the error.
 
+	It is only called if `retries` and `maxRetryTime` have not been exhuasted.
+
 	It is not called for `TypeError` (except network errors) and `AbortError`.
 
 	@example

--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,8 @@ Type: `Function`
 
 Decide if a retry should occur based on the context. Returning true triggers a retry, false aborts with the error.
 
+It is only called if `retries` and `maxRetryTime` have not been exhuasted.
+
 It is not called for `TypeError` (except network errors) and `AbortError`.
 
 ```js


### PR DESCRIPTION
Related: https://github.com/sindresorhus/p-retry/issues/92

This clarifies that `shouldRetry` is only called if `retries` and `maxRetryTime` have not been already been exhausted.