### PR TITLE
Give `shouldRetry` full retry power

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,10 @@ export class AbortError extends Error {
 const createRetryContext = (error, attemptNumber, startTime, options) => {
 	// Minus 1 from attemptNumber because the first attempt does not count as a retry
 	const retriesLeft = options.retries - (attemptNumber - 1);
+
 	const maxRetryTime = options.maxRetryTime ?? Number.POSITIVE_INFINITY;
 	const currentTime = Date.now();
-	const timeLeft = maxRetryTime - (currentTime - startTime);
+	const timeLeft = Math.max(0, maxRetryTime - (currentTime - startTime));
 
 	return Object.freeze({
 		error,
@@ -104,7 +105,7 @@ export default async function pRetry(input, options = {}) {
 			// Calculate delay before next attempt
 			const delayTime = calculateDelay(attemptNumber, options);
 
-			const finalDelay = Math.min(delayTime, timeLeft);
+			const finalDelay = Math.min(delayTime, context.timeLeft);
 
 			// Introduce delay
 			if (finalDelay > 0) {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ export class AbortError extends Error {
 	}
 }
 
-const createRetryContext = (error, attemptNumber, startTime, options) => {
+const createRetryContext = ({error, attemptNumber, startTime, options}) => {
 	// Minus 1 from attemptNumber because the first attempt does not count as a retry
 	const retriesLeft = options.retries - (attemptNumber - 1);
 
@@ -92,7 +92,12 @@ export default async function pRetry(input, options = {}) {
 				throw error;
 			}
 
-			const context = createRetryContext(error, attemptNumber, startTime, options);
+			const context = createRetryContext({
+				error,
+				attemptNumber,
+				startTime,
+				options,
+			});
 
 			// Always call onFailedAttempt
 			await options.onFailedAttempt(context);

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ If the `onFailedAttempt` function throws, all retries will be aborted and the or
 
 Type: `Function`
 
-Decide if a retry should occur based on the context. Returning true triggers a retry, false aborts with the error.
+Decide if a retry should occur based on the context. Returning true triggers a retry, false aborts with the error (regardless of `retries` and `maxRetryTime`).
 
 It is not called for `TypeError` (except network errors) and `AbortError`.
 

--- a/test.js
+++ b/test.js
@@ -214,8 +214,7 @@ test('shouldRetry controls retry behavior', async t => {
 
 test('handles async shouldRetry with maxRetryTime', async t => {
 	let attempts = 0;
-	const start = Date.now();
-	const maxRetryTime = 1000;
+	const retries = 3;
 
 	await t.throwsAsync(pRetry(
 		async () => {
@@ -223,8 +222,8 @@ test('handles async shouldRetry with maxRetryTime', async t => {
 			throw new Error('test');
 		},
 		{
-			retries: 10,
-			maxRetryTime,
+			retries,
+			maxRetryTime: 100,
 			async shouldRetry() {
 				await delay(100);
 				return true;
@@ -232,8 +231,7 @@ test('handles async shouldRetry with maxRetryTime', async t => {
 		},
 	));
 
-	t.true(Date.now() - start <= maxRetryTime + 200);
-	t.true(attempts < 10);
+	t.is(attempts, retries + 1);
 });
 
 test('onFailedAttempt provides correct error details', async t => {

--- a/test.js
+++ b/test.js
@@ -216,13 +216,9 @@ test('handles async shouldRetry with maxRetryTime', async t => {
 	let attempts = 0;
 	const retries = 3;
 
-	await pRetry(
+	await t.throwsAsync(pRetry(
 		async () => {
 			attempts++;
-
-			if (attempts === retries) {
-				return true;
-			}
 
 			throw new Error('test');
 		},
@@ -234,9 +230,9 @@ test('handles async shouldRetry with maxRetryTime', async t => {
 				return true;
 			},
 		},
-	);
+	));
 
-	t.is(attempts, retries);
+	t.is(attempts, retries + 1);
 });
 
 test('onFailedAttempt provides correct error details', async t => {

--- a/test.js
+++ b/test.js
@@ -216,9 +216,14 @@ test('handles async shouldRetry with maxRetryTime', async t => {
 	let attempts = 0;
 	const retries = 3;
 
-	await t.throwsAsync(pRetry(
+	await pRetry(
 		async () => {
 			attempts++;
+
+			if (attempts === retries) {
+				return true;
+			}
+
 			throw new Error('test');
 		},
 		{
@@ -229,9 +234,9 @@ test('handles async shouldRetry with maxRetryTime', async t => {
 				return true;
 			},
 		},
-	));
+	);
 
-	t.is(attempts, retries + 1);
+	t.is(attempts, retries);
 });
 
 test('onFailedAttempt provides correct error details', async t => {


### PR DESCRIPTION
https://github.com/sindresorhus/p-retry/pull/93 clarifies the docs for the _current_ behavior, but this PR alters the behavior so that `options.shouldRetry` has full control over whether the retry should occur.

To me, this is more clear and how I thought it worked after reading the docs. It also gives more power to `options.shouldRetry`, should you want to do have certain conditions count towards retries and not others.

Related:

- https://github.com/sindresorhus/p-retry/issues/92
- https://github.com/sindresorhus/p-retry/pull/93