### PR TITLE
options.shouldConsumeRetry

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,10 +37,10 @@ export type Options = {
 	};
 
 	const result = await pRetry(run, {
-		onFailedAttempt: ({error, attemptNumber, retriesLeft, skip, skippedRetries}) => {
-			console.log(`Attempt ${attemptNumber} failed. There are ${retriesLeft} retries left. Skip? ${skip}. Total skipped: ${skippedRetries}.`);
-			// 1st request => Attempt 1 failed. There are 5 retries left. Skip? false. Total skipped: 0.
-			// 2nd request => Attempt 2 failed. There are 4 retries left. Skip? false. Total skipped: 0.
+		onFailedAttempt: ({error, attemptNumber, retriesLeft}) => {
+			console.log(`Attempt ${attemptNumber} failed. There are ${retriesLeft} retries left.`);
+			// 1st request => Attempt 1 failed. There are 5 retries left.
+			// 2nd request => Attempt 2 failed. There are 4 retries left.
 			// …
 		},
 		retries: 5

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,6 +95,8 @@ export type Options = {
 
 	Skipped errors do not consume retries but still invoke `onFailedAttempt`.
 
+	Provides the same `context` object as `shouldRetry` and `onFailedAttempt`.
+
 	@example
 	```
 	import pRetry from 'p-retry';
@@ -103,13 +105,13 @@ export type Options = {
 
 	const result = await pRetry(run, {
 		retries: 2,
-		shouldSkip: (error) => error instanceof RateLimitError
+		shouldSkip: ({error}) => error instanceof RateLimitError
 	});
 	```
 
 	In the example above, `RateLimitError`s will not count against the retry limit.
 	*/
-	readonly shouldSkip?: (error: Error) => boolean;
+	readonly shouldSkip?: (context: RetryContext) => boolean | Promise<boolean>;
 
 	/**
 	The maximum amount of times to retry the operation.

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,7 @@ export type Options = {
 	const run = async () => { … };
 
 	const result = await pRetry(run, {
-		shouldRetry: ({error, attemptNumber, retriesLeft, skip}) => !skip && !(error instanceof CustomError)
+		shouldRetry: ({error, attemptNumber, retriesLeft}) => !(error instanceof CustomError)
 	});
 	```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,27 @@ export type Options = {
 	readonly shouldRetry?: (context: RetryContext) => boolean | Promise<boolean>;
 
 	/**
+	Decide if an error should be skipped and not count against the retry limit.
+
+	Skipped errors do not consume retries but still invoke `onFailedAttempt`.
+
+	@example
+	```
+	import pRetry from 'p-retry';
+
+	const run = async () => { … };
+
+	const result = await pRetry(run, {
+		retries: 2,
+		shouldSkip: (error) => error instanceof RateLimitError
+	});
+	```
+
+	In the example above, `RateLimitError`s will not count against the retry limit.
+	*/
+	readonly shouldSkip?: (error: Error) => boolean;
+
+	/**
 	The maximum amount of times to retry the operation.
 
 	@default 10

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,7 +93,7 @@ export type Options = {
 	readonly shouldRetry?: (context: RetryContext) => boolean | Promise<boolean>;
 
 	/**
-	Decide if an error should be skipped and not count against the retry limit.
+	Decide if a error should be considered skipped based on the context.
 
 	Skipped errors do not consume retries or impact backoff, but still invoke `onFailedAttempt`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ export class AbortError extends Error {
 	readonly originalError: Error;
 
 	/**
-	Abort retrying and reject the promise.
+	Abort retrying and reject the promise. No callback functions will be called.
 
 	@param message - An error message or a custom error.
 	*/
@@ -14,12 +14,16 @@ export type RetryContext = {
 	readonly error: Error;
 	readonly attemptNumber: number;
 	readonly retriesLeft: number;
-	readonly retriesUsed: number;
+	readonly retriesConsumed: number;
 };
 
 export type Options = {
 	/**
 	Callback invoked on each failure. Receives a context object containing the error and retry state information.
+
+	The function is called before `shouldConsumeRetry` and `shouldRetry`, for all errors except `AbortError`.
+
+	The function is not called on `AbortError`.
 
 	@example
 	```
@@ -36,10 +40,10 @@ export type Options = {
 	};
 
 	const result = await pRetry(run, {
-		onFailedAttempt: ({error, attemptNumber, retriesLeft, retriesUsed}) => {
-			console.log(`Attempt ${attemptNumber} failed. ${retriesLeft} retries left. ${retriesUsed} retries used.`);
-			// 1st request => Attempt 1 failed. 5 retries left. 0 retries used.
-			// 2nd request => Attempt 2 failed. 4 retries left. 1 retries used.
+		onFailedAttempt: ({error, attemptNumber, retriesLeft, retriesConsumed}) => {
+			console.log(`Attempt ${attemptNumber} failed. ${retriesLeft} retries left. ${retriesConsumed} retries consumed.`);
+			// 1st request => Attempt 1 failed. 5 retries left. 0 retries consumed.
+			// 2nd request => Attempt 2 failed. 4 retries left. 1 retries consumed.
 			// …
 		},
 		retries: 5
@@ -66,19 +70,15 @@ export type Options = {
 	```
 
 	If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error.
-
-	The callback is invoked regardless of the outcome of `shouldConsumeRetry`.
 	*/
 	readonly onFailedAttempt?: (context: RetryContext) => void | Promise<void>;
 
 	/**
 	Decide if a retry should occur based on the context. Returning true triggers a retry, false aborts with the error.
 
-	It is only called if `retries` and `maxRetryTime` have not been exhausted.
+	The function is called after `onFailedAttempt` and `shouldConsumeRetry`.
 
-	It is not called for `TypeError` (except network errors) and `AbortError`.
-
-	If the `shouldRetry` function throws, all retries will be aborted and the original promise will reject with the thrown error.
+	The function is not called on `AbortError`, `TypeError` (except network errors), or if `retries` or `maxRetryTime` are exhausted.
 
 	@example
 	```
@@ -92,15 +92,19 @@ export type Options = {
 	```
 
 	In the example above, the operation will be retried unless the error is an instance of `CustomError`.
+
+	If the `shouldRetry` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 	*/
 	readonly shouldRetry?: (context: RetryContext) => boolean | Promise<boolean>;
 
 	/**
-	Decide if the failure should consume a retry based on the context.
+	Decide if this failure should consume a retry from the `retries` budget.
 
-	Returning `false` treats the attempt as skipped: retries and backoff are not consumed, but `maxRetryTime` still applies.
+	When `false` is returned, the failure will not consume a retry or increment backoff values, but is still subject to `maxRetryTime`.
 
-	Receives the same `context` object as `shouldRetry` and `onFailedAttempt`.
+	The function is called after `onFailedAttempt`, but before `shouldRetry`.
+
+	The function is not called on `AbortError`.
 
 	@example
 	```
@@ -117,7 +121,7 @@ export type Options = {
 	});
 	```
 
-	In the example above, `RateLimitError`s will not count against the retry limit.
+	In the example above, `RateLimitError`s will not decrement the available `retries`.
 
 	If the `shouldConsumeRetry` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 	*/
@@ -139,6 +143,8 @@ export type Options = {
 
 	/**
 	The number of milliseconds before starting the first retry.
+
+	Set this to `0` to retry immediately with no delay.
 
 	@default 1000
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,10 +36,10 @@ export type Options = {
 	};
 
 	const result = await pRetry(run, {
-		onFailedAttempt: ({error, attemptNumber, retriesLeft}) => {
-			console.log(`Attempt ${attemptNumber} failed. There are ${retriesLeft} retries left.`);
-			// 1st request => Attempt 1 failed. There are 5 retries left.
-			// 2nd request => Attempt 2 failed. There are 4 retries left.
+		onFailedAttempt: ({error, attemptNumber, retriesLeft, retriesUsed}) => {
+			console.log(`Attempt ${attemptNumber} failed. ${retriesLeft} retries left. ${retriesUsed} retries used.`);
+			// 1st request => Attempt 1 failed. 5 retries left. 0 retries used.
+			// 2nd request => Attempt 2 failed. 4 retries left. 1 retries used.
 			// …
 		},
 		retries: 5
@@ -77,6 +77,8 @@ export type Options = {
 	It is only called if `retries` and `maxRetryTime` have not been exhausted.
 
 	It is not called for `TypeError` (except network errors) and `AbortError`.
+
+	If the `shouldRetry` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
 	@example
 	```
@@ -116,6 +118,8 @@ export type Options = {
 	```
 
 	In the example above, `RateLimitError`s will not count against the retry limit.
+
+	If the `shouldSkip` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 	*/
 	readonly shouldSkip?: (context: RetryContext) => boolean | Promise<boolean>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -162,6 +162,8 @@ export type Options = {
 	The maximum time (in milliseconds) that the retried operation is allowed to run.
 
 	@default Infinity
+
+	Measured with a monotonic clock (`performance.now()`) so system clock adjustments do not affect the limit.
 	*/
 	readonly maxRetryTime?: number;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,8 @@ export type RetryContext = {
 	readonly attemptNumber: number;
 	readonly retriesLeft: number;
 	readonly skippedRetries: number;
+	readonly startTime: number;
+	readonly maxRetryTime: number;
 	readonly skip: boolean;
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ export type RetryContext = {
 
 export type Options = {
 	/**
-	Callback invoked on each retry. Receives a context object containing the error and retry state information.
+	Callback invoked on each failure. Receives a context object containing the error and retry state information.
 
 	@example
 	```
@@ -66,6 +66,8 @@ export type Options = {
 	```
 
 	If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error.
+
+	The callback is invoked regardless of the outcome of `shouldSkip`.
 	*/
 	readonly onFailedAttempt?: (context: RetryContext) => void | Promise<void>;
 
@@ -92,7 +94,7 @@ export type Options = {
 	readonly shouldRetry?: (context: RetryContext) => boolean | Promise<boolean>;
 
 	/**
-	Decide if a error should be considered skipped based on the context.
+	Decide if an error should be considered skipped based on the context.
 
 	Skipped errors do not expend retries or increment backoff, but are still subject to `maxRetryTime`.
 
@@ -106,7 +108,10 @@ export type Options = {
 
 	const result = await pRetry(run, {
 		retries: 2,
-		shouldSkip: ({error}) => error instanceof RateLimitError
+		shouldSkip: ({error, retriesLeft}) => {
+			console.log(`Retries left: ${retriesLeft}`);
+			return error instanceof RateLimitError;
+		},
 	});
 	```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,7 +94,7 @@ export type Options = {
 	/**
 	Decide if a error should be considered skipped based on the context.
 
-	Skipped errors do not consume retries or impact backoff, but still invoke `onFailedAttempt`.
+	Skipped errors do not expend retries or increment backoff, but are still subject to `maxRetryTime`.
 
 	Receives the same `context` object as `shouldRetry` and `onFailedAttempt`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,10 +14,7 @@ export type RetryContext = {
 	readonly error: Error;
 	readonly attemptNumber: number;
 	readonly retriesLeft: number;
-	readonly skippedRetries: number;
-	readonly startTime: number;
-	readonly maxRetryTime: number;
-	readonly skip: boolean;
+	readonly retriesUsed: number;
 };
 
 export type Options = {
@@ -99,9 +96,7 @@ export type Options = {
 
 	Skipped errors do not consume retries or impact backoff, but still invoke `onFailedAttempt`.
 
-	Provides the same `context` object as `shouldRetry` and `onFailedAttempt`.
-
-	`RetryContext.skip` is always `false` within the `shouldSkip` callback.
+	Receives the same `context` object as `shouldRetry` and `onFailedAttempt`.
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,7 @@ export type Options = {
 
 	If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
-	The callback is invoked regardless of the outcome of `shouldSkip`.
+	The callback is invoked regardless of the outcome of `shouldConsumeRetry`.
 	*/
 	readonly onFailedAttempt?: (context: RetryContext) => void | Promise<void>;
 
@@ -96,9 +96,9 @@ export type Options = {
 	readonly shouldRetry?: (context: RetryContext) => boolean | Promise<boolean>;
 
 	/**
-	Decide if an error should be considered skipped based on the context.
+	Decide if the failure should consume a retry based on the context.
 
-	Skipped errors do not expend retries or increment backoff, but are still subject to `maxRetryTime`.
+	Returning `false` treats the attempt as skipped: retries and backoff are not consumed, but `maxRetryTime` still applies.
 
 	Receives the same `context` object as `shouldRetry` and `onFailedAttempt`.
 
@@ -110,18 +110,18 @@ export type Options = {
 
 	const result = await pRetry(run, {
 		retries: 2,
-		shouldSkip: ({error, retriesLeft}) => {
+		shouldConsumeRetry: ({error, retriesLeft}) => {
 			console.log(`Retries left: ${retriesLeft}`);
-			return error instanceof RateLimitError;
+			return !(error instanceof RateLimitError);
 		},
 	});
 	```
 
 	In the example above, `RateLimitError`s will not count against the retry limit.
 
-	If the `shouldSkip` function throws, all retries will be aborted and the original promise will reject with the thrown error.
+	If the `shouldConsumeRetry` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 	*/
-	readonly shouldSkip?: (context: RetryContext) => boolean | Promise<boolean>;
+	readonly shouldConsumeRetry?: (context: RetryContext) => boolean | Promise<boolean>;
 
 	/**
 	The maximum amount of times to retry the operation.

--- a/index.js
+++ b/index.js
@@ -50,7 +50,11 @@ export class AbortError extends Error {
 }
 
 const createRetryContext = async (error, attemptNumber, retriesLeft, options) => {
-	const context = {error, attemptNumber, retriesLeft};
+	const context = {
+		error,
+		attemptNumber,
+		retriesLeft
+	};
 
 	if (! await options.shouldSkip(context)) {	
 		context.retriesLeft--;

--- a/index.js
+++ b/index.js
@@ -82,9 +82,9 @@ async function onAttemptFailure(context, options) {
 	const timeLeft = maxRetryTime - timeElapsed;
 
 	if (
-		timeLeft <= 0 ||
-		(!context.skip && context.retriesLeft <= 0) ||
-		!(await options.shouldRetry(context))
+		timeLeft <= 0
+		|| (!context.skip && context.retriesLeft <= 0)
+		|| !(await options.shouldRetry(context))
 	) {
 		throw normalizedError;
 	}
@@ -160,8 +160,8 @@ export default async function pRetry(input, options = {}) {
 		const retriesLeft = Number.isFinite(totalRetries)
 			? Math.max(0, totalRetries - retriesUsed)
 			: totalRetries;
-		let skippedRetries = Math.max(0, (attemptNumber - 1) - retriesUsed);
-		let context = {
+		const skippedRetries = Math.max(0, (attemptNumber - 1) - retriesUsed);
+		const context = {
 			error,
 			attemptNumber,
 			retriesLeft,
@@ -170,7 +170,7 @@ export default async function pRetry(input, options = {}) {
 			maxRetryTime,
 		};
 
-		context.skip = await options.shouldSkip(Object.freeze(Object.assign({}, context, {skip: false})));
+		context.skip = await options.shouldSkip(Object.freeze({...context, skip: false}));
 
 		if (context.skip) {
 			context.skippedRetries++;

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ export default async function pRetry(input, options = {}) {
 
 			await onAttemptFailure(context, options, startTime, maxRetryTime);
 
-			if (options.shouldSkip(error)) {
+			if (await options.shouldSkip(context)) {
 				attemptNumber = Math.max(0, attemptNumber - 1);
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -88,9 +88,10 @@ async function onAttemptFailure(context, options, startTime, maxRetryTime) {
 	// Always call onFailedAttempt
 	await options.onFailedAttempt(context);
 
-	const currentTime = Date.now();
+	const timeLeft = maxRetryTime - (Date.now() - startTime);
+
 	if (
-		currentTime - startTime >= maxRetryTime
+		timeLeft <= 0
 		|| retriesLeft <= 0
 		|| !(await options.shouldRetry(context))
 	) {
@@ -99,12 +100,6 @@ async function onAttemptFailure(context, options, startTime, maxRetryTime) {
 
 	// Calculate delay before next attempt
 	const delayTime = calculateDelay(attemptNumber, options);
-
-	// Ensure that delay does not exceed maxRetryTime
-	const timeLeft = maxRetryTime - (currentTime - startTime);
-	if (timeLeft <= 0) {
-		throw normalizedError; // Max retry time exceeded
-	}
 
 	const finalDelay = Math.min(delayTime, timeLeft);
 

--- a/index.js
+++ b/index.js
@@ -109,10 +109,9 @@ async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, o
 		throw normalizedError;
 	}
 
-	const shouldRetry = await options.shouldRetry(context);
 	const remainingTime = calculateRemainingTime(startTime, maxRetryTime);
 
-	if (remainingTime <= 0 || retriesLeft <= 0 || !shouldRetry) {
+	if (remainingTime <= 0 || retriesLeft <= 0 || !await options.shouldRetry(context)) {
 		throw normalizedError;
 	}
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function calculateRemainingTime(start, max) {
 async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, options}) {
 	let normalizedError = error;
 
-	if (!(error instanceof Error)) {
+	if (!(normalizedError instanceof Error)) {
 		normalizedError = new TypeError(`Non-error was thrown: "${error}". You should only throw errors.`);
 	}
 

--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ export class AbortError extends Error {
 	}
 }
 
-function calculateDelay(context, options) {
-	const attempt = Math.max(1, context.attemptNumber - context.skippedRetries);
+function calculateDelay(retries, options) {
+	const attempt = Math.max(1, retries + 1);
 	const random = options.randomize ? (Math.random() + 1) : 1;
 
 	let timeout = Math.round(random * Math.max(options.minTimeout, 1) * (options.factor ** (attempt - 1)));
@@ -59,70 +59,90 @@ function calculateDelay(context, options) {
 	return timeout;
 }
 
-function normalizeError(error) {
-	if (!(error instanceof Error)) {
-		return new TypeError(`Non-error was thrown: "${error}". You should only throw errors.`);
+function calculateRemainingTime(start, max) {
+	if (!Number.isFinite(max)) {
+		return max;
 	}
 
-	if (error instanceof AbortError) {
-		throw error.originalError;
-	}
-
-	if (error instanceof TypeError && !isNetworkError(error)) {
-		throw error;
-	}
-
-	return error;
+	return max - (Date.now() - start);
 }
 
-async function onAttemptFailure(context, options) {
-	const {error: normalizedError, startTime, maxRetryTime} = context;
+async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, options}) {
+	let normalizedError = error;
+
+	if (!(error instanceof Error)) {
+		normalizedError = new TypeError(`Non-error was thrown: "${error}". You should only throw errors.`);
+	}
+
+	if (normalizedError instanceof AbortError) {
+		throw normalizedError.originalError;
+	}
+
+	const retriesLeft = Number.isFinite(options.retries)
+		? Math.max(0, options.retries - retriesUsed)
+		: options.retries;
+
+	const maxRetryTime = options.maxRetryTime ?? Number.POSITIVE_INFINITY;
+
+	const context = Object.freeze({
+		error: normalizedError,
+		attemptNumber,
+		retriesLeft,
+		retriesUsed,
+	});
+
+	await options.onFailedAttempt(context);
+
+	if (calculateRemainingTime(startTime, maxRetryTime) <= 0) {
+		throw normalizedError;
+	}
+
+	if (await options.shouldSkip(context)) {
+		if (calculateRemainingTime(startTime, maxRetryTime) <= 0) {
+			throw normalizedError;
+		}
+
+		return false;
+	}
 
 	if (normalizedError instanceof TypeError && !isNetworkError(normalizedError)) {
 		throw normalizedError;
 	}
 
-	await options.onFailedAttempt(context);
+	const shouldRetry = await options.shouldRetry(context);
+	const remainingTime = calculateRemainingTime(startTime, maxRetryTime);
 
-	const currentTime = Date.now();
-	const timeElapsed = currentTime - startTime;
-	const timeLeft = maxRetryTime - timeElapsed;
-
-	if (
-		timeLeft <= 0
-		|| (!context.skip && context.retriesLeft <= 0)
-		|| !(await options.shouldRetry(context))
-	) {
+	if (remainingTime <= 0 || retriesLeft <= 0 || !shouldRetry) {
 		throw normalizedError;
 	}
 
-	if (!context.skip) {
-		const delayTime = calculateDelay(context, options);
-		const finalDelay = Math.min(delayTime, timeLeft);
+	const delayTime = calculateDelay(retriesUsed, options);
+	const finalDelay = Math.min(delayTime, remainingTime);
 
-		if (finalDelay > 0) {
-			await new Promise((resolve, reject) => {
-				const onAbort = () => {
-					clearTimeout(timeoutToken);
-					options.signal?.removeEventListener('abort', onAbort);
-					reject(options.signal.reason);
-				};
+	if (finalDelay > 0) {
+		await new Promise((resolve, reject) => {
+			const onAbort = () => {
+				clearTimeout(timeoutToken);
+				options.signal?.removeEventListener('abort', onAbort);
+				reject(options.signal.reason);
+			};
 
-				const timeoutToken = setTimeout(() => {
-					options.signal?.removeEventListener('abort', onAbort);
-					resolve();
-				}, finalDelay);
+			const timeoutToken = setTimeout(() => {
+				options.signal?.removeEventListener('abort', onAbort);
+				resolve();
+			}, finalDelay);
 
-				if (options.unref) {
-					timeoutToken.unref?.();
-				}
+			if (options.unref) {
+				timeoutToken.unref?.();
+			}
 
-				options.signal?.addEventListener('abort', onAbort, {once: true});
-			});
-		}
+			options.signal?.addEventListener('abort', onAbort, {once: true});
+		});
 	}
 
 	options.signal?.throwIfAborted();
+
+	return true;
 }
 
 export default async function pRetry(input, options = {}) {
@@ -138,6 +158,7 @@ export default async function pRetry(input, options = {}) {
 	options.factor ??= 2;
 	options.minTimeout ??= 1000;
 	options.maxTimeout ??= Number.POSITIVE_INFINITY;
+	options.maxRetryTime ??= Number.POSITIVE_INFINITY;
 	options.randomize ??= false;
 	options.onFailedAttempt ??= () => {};
 	options.shouldRetry ??= () => true;
@@ -147,8 +168,7 @@ export default async function pRetry(input, options = {}) {
 	validateNumberOption('factor', options.factor, {min: 0, allowInfinity: false});
 	validateNumberOption('minTimeout', options.minTimeout, {min: 0, allowInfinity: false});
 	validateNumberOption('maxTimeout', options.maxTimeout, {min: 0, allowInfinity: true});
-	const resolvedMaxRetryTime = options.maxRetryTime ?? Number.POSITIVE_INFINITY;
-	validateNumberOption('maxRetryTime', resolvedMaxRetryTime, {min: 0, allowInfinity: true});
+	validateNumberOption('maxRetryTime', options.maxRetryTime, {min: 0, allowInfinity: true});
 
 	// Treat non-positive factor as 1 to avoid zero backoff or negative behavior
 	if (!(options.factor > 0)) {
@@ -160,40 +180,8 @@ export default async function pRetry(input, options = {}) {
 	let attemptNumber = 0;
 	let retriesUsed = 0;
 	const startTime = Date.now();
-	const maxRetryTime = resolvedMaxRetryTime;
-	const totalRetries = options.retries;
 
-	const createRetryContext = async ({error, attemptNumber, retriesUsed}) => {
-		const normalizedError = normalizeError(error);
-		const retriesLeft = Number.isFinite(totalRetries)
-			? Math.max(0, totalRetries - retriesUsed)
-			: totalRetries;
-		const skippedRetries = Math.max(0, (attemptNumber - 1) - retriesUsed);
-		const context = {
-			error: normalizedError,
-			attemptNumber,
-			retriesLeft,
-			skippedRetries,
-			skip: false,
-			startTime,
-			maxRetryTime,
-		};
-
-		try {
-			context.skip = await options.shouldSkip(Object.freeze({...context}));
-		} catch (error) {
-			await onAttemptFailure(Object.freeze({...context}), options);
-			throw error;
-		}
-
-		if (context.skip) {
-			context.skippedRetries++;
-		}
-
-		return Object.freeze(context);
-	};
-
-	while (Number.isFinite(totalRetries) ? retriesUsed <= totalRetries : true) {
+	while (Number.isFinite(options.retries) ? retriesUsed <= options.retries : true) {
 		attemptNumber++;
 
 		try {
@@ -205,9 +193,13 @@ export default async function pRetry(input, options = {}) {
 
 			return result;
 		} catch (error) {
-			const context = await createRetryContext({error, attemptNumber, retriesUsed});
-			await onAttemptFailure(context, options);
-			if (!context.skip) {
+			if (await onAttemptFailure({
+				error,
+				attemptNumber,
+				retriesUsed,
+				startTime,
+				options,
+			})) {
 				retriesUsed++;
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function calculateRemainingTime(start, max) {
 async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, options}) {
 	let normalizedError = error;
 
-	if (!(normalizedError instanceof Error)) {
+	if (!(error instanceof Error)) {
 		normalizedError = new TypeError(`Non-error was thrown: "${error}". You should only throw errors.`);
 	}
 

--- a/index.js
+++ b/index.js
@@ -95,22 +95,30 @@ async function onAttemptFailure({error, attemptNumber, retriesConsumed, startTim
 		throw normalizedError;
 	}
 
-	if (!await options.shouldConsumeRetry(context)) {
-		if (calculateRemainingTime(startTime, maxRetryTime) <= 0) {
-			throw normalizedError;
-		}
-
-		return false;
-	}
-
-	if (normalizedError instanceof TypeError && !isNetworkError(normalizedError)) {
-		throw normalizedError;
-	}
+	const consumeRetry = await options.shouldConsumeRetry(context);
 
 	const remainingTime = calculateRemainingTime(startTime, maxRetryTime);
 
-	if (remainingTime <= 0 || retriesLeft <= 0 || !await options.shouldRetry(context)) {
+	if (remainingTime <= 0 || retriesLeft <= 0) {
 		throw normalizedError;
+	}
+
+	if (normalizedError instanceof TypeError && !isNetworkError(normalizedError)) {
+		if (consumeRetry) {
+			throw normalizedError;
+		}
+
+		options.signal?.throwIfAborted();
+		return false;
+	}
+
+	if (!await options.shouldRetry(context)) {
+		throw normalizedError;
+	}
+
+	if (!consumeRetry) {
+		options.signal?.throwIfAborted();
+		return false;
 	}
 
 	const delayTime = calculateDelay(retriesConsumed, options);

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function calculateRemainingTime(start, max) {
 		return max;
 	}
 
-	return max - (Date.now() - start);
+	return max - (performance.now() - start);
 }
 
 async function onAttemptFailure({error, attemptNumber, retriesConsumed, startTime, options}) {
@@ -176,7 +176,7 @@ export default async function pRetry(input, options = {}) {
 
 	let attemptNumber = 0;
 	let retriesConsumed = 0;
-	const startTime = Date.now();
+	const startTime = performance.now();
 
 	while (Number.isFinite(options.retries) ? retriesConsumed <= options.retries : true) {
 		attemptNumber++;

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function calculateRemainingTime(start, max) {
 	return max - (Date.now() - start);
 }
 
-async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, options}) {
+async function onAttemptFailure({error, attemptNumber, retriesConsumed, startTime, options}) {
 	const normalizedError = error instanceof Error
 		? error
 		: new TypeError(`Non-error was thrown: "${error}". You should only throw errors.`);
@@ -77,7 +77,7 @@ async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, o
 	}
 
 	const retriesLeft = Number.isFinite(options.retries)
-		? Math.max(0, options.retries - retriesUsed)
+		? Math.max(0, options.retries - retriesConsumed)
 		: options.retries;
 
 	const maxRetryTime = options.maxRetryTime ?? Number.POSITIVE_INFINITY;
@@ -86,7 +86,7 @@ async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, o
 		error: normalizedError,
 		attemptNumber,
 		retriesLeft,
-		retriesUsed,
+		retriesConsumed,
 	});
 
 	await options.onFailedAttempt(context);
@@ -95,7 +95,7 @@ async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, o
 		throw normalizedError;
 	}
 
-	if (await options.shouldSkip(context)) {
+	if (!await options.shouldConsumeRetry(context)) {
 		if (calculateRemainingTime(startTime, maxRetryTime) <= 0) {
 			throw normalizedError;
 		}
@@ -113,7 +113,7 @@ async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, o
 		throw normalizedError;
 	}
 
-	const delayTime = calculateDelay(retriesUsed, options);
+	const delayTime = calculateDelay(retriesConsumed, options);
 	const finalDelay = Math.min(delayTime, remainingTime);
 
 	if (finalDelay > 0) {
@@ -159,7 +159,7 @@ export default async function pRetry(input, options = {}) {
 	options.randomize ??= false;
 	options.onFailedAttempt ??= () => {};
 	options.shouldRetry ??= () => true;
-	options.shouldSkip ??= () => false;
+	options.shouldConsumeRetry ??= () => true;
 
 	// Validate numeric options and normalize edge cases
 	validateNumberOption('factor', options.factor, {min: 0, allowInfinity: false});
@@ -175,10 +175,10 @@ export default async function pRetry(input, options = {}) {
 	options.signal?.throwIfAborted();
 
 	let attemptNumber = 0;
-	let retriesUsed = 0;
+	let retriesConsumed = 0;
 	const startTime = Date.now();
 
-	while (Number.isFinite(options.retries) ? retriesUsed <= options.retries : true) {
+	while (Number.isFinite(options.retries) ? retriesConsumed <= options.retries : true) {
 		attemptNumber++;
 
 		try {
@@ -193,11 +193,11 @@ export default async function pRetry(input, options = {}) {
 			if (await onAttemptFailure({
 				error,
 				attemptNumber,
-				retriesUsed,
+				retriesConsumed,
 				startTime,
 				options,
 			})) {
-				retriesUsed++;
+				retriesConsumed++;
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -49,11 +49,11 @@ export class AbortError extends Error {
 	}
 }
 
-function calculateDelay(retries, options) {
-	const attempt = Math.max(1, retries + 1);
+function calculateDelay(retriesConsumed, options) {
+	const attempt = Math.max(1, retriesConsumed + 1);
 	const random = options.randomize ? (Math.random() + 1) : 1;
 
-	let timeout = Math.round(random * Math.max(options.minTimeout, 1) * (options.factor ** (attempt - 1)));
+	let timeout = Math.round(random * options.minTimeout * (options.factor ** (attempt - 1)));
 	timeout = Math.min(timeout, options.maxTimeout);
 
 	return timeout;

--- a/index.js
+++ b/index.js
@@ -68,11 +68,9 @@ function calculateRemainingTime(start, max) {
 }
 
 async function onAttemptFailure({error, attemptNumber, retriesUsed, startTime, options}) {
-	let normalizedError = error;
-
-	if (!(error instanceof Error)) {
-		normalizedError = new TypeError(`Non-error was thrown: "${error}". You should only throw errors.`);
-	}
+	const normalizedError = error instanceof Error
+		? error
+		: new TypeError(`Non-error was thrown: "${error}". You should only throw errors.`);
 
 	if (normalizedError instanceof AbortError) {
 		throw normalizedError.originalError;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,11 +9,13 @@ expectType<Promise<number>>(
 );
 expectType<Promise<void>>(
 	pRetry(() => {}, { // eslint-disable-line @typescript-eslint/no-empty-function
-		onFailedAttempt(context) {
-			expectType<RetryContext>(context);
-			expectType<number>(context.attemptNumber);
-			expectType<number>(context.retriesLeft);
-		},
+			onFailedAttempt(context) {
+				expectType<RetryContext>(context);
+				expectType<number>(context.attemptNumber);
+				expectType<number>(context.retriesLeft);
+				expectType<number>(context.skippedRetries);
+				expectType<boolean>(context.skip);
+			},
 	}),
 );
 expectType<Promise<string>>(
@@ -27,6 +29,8 @@ expectType<Promise<string>>(
 		async shouldSkip(context) {
 			expectType<RetryContext>(context);
 			expectType<Error>(context.error);
+			expectType<number>(context.skippedRetries);
+			expectType<boolean>(context.skip);
 			return false;
 		},
 		minTimeout: 0,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -22,6 +22,17 @@ expectType<Promise<string>>(
 	}),
 );
 
+expectType<Promise<string>>(
+	pRetry(async () => 'value', {
+		async shouldSkip(context) {
+			expectType<RetryContext>(context);
+			expectType<Error>(context.error);
+			return false;
+		},
+		minTimeout: 0,
+	}),
+);
+
 const abortError = new AbortError('foo');
 new AbortError(new Error('foo')); // eslint-disable-line no-new
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,13 +9,13 @@ expectType<Promise<number>>(
 );
 expectType<Promise<void>>(
 	pRetry(() => {}, { // eslint-disable-line @typescript-eslint/no-empty-function
-			onFailedAttempt(context) {
-				expectType<RetryContext>(context);
-				expectType<number>(context.attemptNumber);
-				expectType<number>(context.retriesLeft);
-				expectType<number>(context.skippedRetries);
-				expectType<boolean>(context.skip);
-			},
+		onFailedAttempt(context) {
+			expectType<RetryContext>(context);
+			expectType<number>(context.attemptNumber);
+			expectType<number>(context.retriesLeft);
+			expectType<number>(context.skippedRetries);
+			expectType<boolean>(context.skip);
+		},
 	}),
 );
 expectType<Promise<string>>(

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,7 +13,7 @@ expectType<Promise<void>>(
 			expectType<RetryContext>(context);
 			expectType<number>(context.attemptNumber);
 			expectType<number>(context.retriesLeft);
-			expectType<number>(context.retriesUsed);
+			expectType<number>(context.retriesConsumed);
 		},
 	}),
 );

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -25,10 +25,10 @@ expectType<Promise<string>>(
 
 expectType<Promise<string>>(
 	pRetry(async () => 'value', {
-		async shouldSkip(context) {
+		async shouldConsumeRetry(context) {
 			expectType<RetryContext>(context);
 			expectType<Error>(context.error);
-			return false;
+			return true;
 		},
 		minTimeout: 0,
 	}),

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,8 +13,7 @@ expectType<Promise<void>>(
 			expectType<RetryContext>(context);
 			expectType<number>(context.attemptNumber);
 			expectType<number>(context.retriesLeft);
-			expectType<number>(context.skippedRetries);
-			expectType<boolean>(context.skip);
+			expectType<number>(context.retriesUsed);
 		},
 	}),
 );
@@ -29,8 +28,6 @@ expectType<Promise<string>>(
 		async shouldSkip(context) {
 			expectType<RetryContext>(context);
 			expectType<Error>(context.error);
-			expectType<number>(context.skippedRetries);
-			expectType<boolean>(context.skip);
 			return false;
 		},
 		minTimeout: 0,

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ const run = async () => {
 };
 
 const result = await pRetry(run, {
-	onFailedAttempt: ({error, attemptNumber, retriesLeft, skip, skippedRetries}) => {
+	onFailedAttempt: ({error, attemptNumber, retriesLeft}) => {
 		console.log(`Attempt ${attemptNumber} failed. There are ${retriesLeft} retries left.`);
 		// 1st request => Attempt 1 failed. There are 5 retries left.
 		// 2nd request => Attempt 2 failed. There are 4 retries left.
@@ -113,7 +113,7 @@ import pRetry from 'p-retry';
 const run = async () => { … };
 
 const result = await pRetry(run, {
-	shouldRetry: ({error, attemptNumber, retriesLeft, skip}) => !skip && !(error instanceof CustomError)
+	shouldRetry: ({error, attemptNumber, retriesLeft}) => !(error instanceof CustomError)
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,27 @@ const result = await pRetry(run, {
 
 In the example above, the operation will be retried unless the error is an instance of `CustomError`.
 
+##### shouldSkip(error)
+
+Type: `Function`
+
+Decide if an error should be skipped and not count against the retry limit.
+
+Skipped errors do not consume retries but still invoke `onFailedAttempt`.
+
+```js
+import pRetry from 'p-retry';
+
+const run = async () => { … };
+
+const result = await pRetry(run, {
+	retries: 2,
+	shouldSkip: (error) => error instanceof RateLimitError
+});
+```
+
+In the example above, `RateLimitError`s will not count against the retry limit.
+
 ##### retries
 
 Type: `number`\

--- a/readme.md
+++ b/readme.md
@@ -119,11 +119,13 @@ const result = await pRetry(run, {
 
 In the example above, the operation will be retried unless the error is an instance of `CustomError`.
 
-##### shouldSkip(error)
+##### shouldSkip(context)
 
 Type: `Function`
 
 Decide if an error should be skipped and not count against the retry limit.
+
+The `context` object contains the same information as `shouldRetry` and `onFailedAttempt`, including `error`, `attemptNumber`, and `retriesLeft`.
 
 Skipped errors do not consume retries but still invoke `onFailedAttempt`.
 
@@ -134,7 +136,10 @@ const run = async () => { … };
 
 const result = await pRetry(run, {
 	retries: 2,
-	shouldSkip: (error) => error instanceof RateLimitError
+	shouldSkip: ({error, retriesLeft}) => {
+		console.log(`Retries left: ${retriesLeft}`);
+		return error instanceof RateLimitError;
+	},
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -68,9 +68,9 @@ const run = async () => {
 
 const result = await pRetry(run, {
 	onFailedAttempt: ({error, attemptNumber, retriesLeft, skip, skippedRetries}) => {
-		console.log(`Attempt ${attemptNumber} failed. There are ${retriesLeft} retries left. Skip? ${skip}. Total skipped: ${skippedRetries}.`);
-		// 1st request => Attempt 1 failed. There are 5 retries left. Skip? false. Total skipped: 0.
-		// 2nd request => Attempt 2 failed. There are 4 retries left. Skip? false. Total skipped: 0.
+		console.log(`Attempt ${attemptNumber} failed. There are ${retriesLeft} retries left.`);
+		// 1st request => Attempt 1 failed. There are 5 retries left.
+		// 2nd request => Attempt 2 failed. There are 4 retries left.
 		// …
 	},
 	retries: 5

--- a/readme.md
+++ b/readme.md
@@ -67,10 +67,10 @@ const run = async () => {
 };
 
 const result = await pRetry(run, {
-	onFailedAttempt: ({error, attemptNumber, retriesLeft}) => {
-		console.log(`Attempt ${attemptNumber} failed. There are ${retriesLeft} retries left.`);
-		// 1st request => Attempt 1 failed. There are 5 retries left.
-		// 2nd request => Attempt 2 failed. There are 4 retries left.
+	onFailedAttempt: ({error, attemptNumber, retriesLeft, retriesUsed}) => {
+		console.log(`Attempt ${attemptNumber} failed. ${retriesLeft} retries left. ${retriesUsed} retries used.`);
+		// 1st request => Attempt 1 failed. 5 retries left. 0 retries used.
+		// 2nd request => Attempt 2 failed. 4 retries left. 1 retries used.
 		// …
 	},
 	retries: 5
@@ -138,10 +138,7 @@ const run = async () => { … };
 
 const result = await pRetry(run, {
 	retries: 2,
-	shouldSkip: ({error, retriesLeft}) => {
-		console.log(`Retries left: ${retriesLeft}`);
-		return error instanceof RateLimitError;
-	},
+	shouldSkip: ({error, retriesLeft}) => error instanceof RateLimitError,
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -47,11 +47,23 @@ Receives the number of attempts as the first argument and is expected to return 
 
 Type: `object`
 
+##### RetryContext
+
+The callbacks below receive a [`RetryContext`](#retrycontext) object describing the current attempt:
+
+- `error`
+- `attemptNumber`
+- `startTime`:
+- `maxRetryTime`
+- `retriesLeft`
+- `skippedRetries`: number of failures where `shouldSkip` returned `true`.
+- `skip`: whether this attempted will be skipped. Note: this will always `false` within `shouldSkip`, as the outcome has not yet been determined.
+
 ##### onFailedAttempt(context)
 
 Type: `Function`
 
-Callback invoked on each retry. Receives a context object containing the error and retry state information.
+Callback invoked on each failure. Receives a [`RetryContext`](#retrycontext).
 
 ```js
 import pRetry from 'p-retry';
@@ -95,13 +107,13 @@ const result = await pRetry(run, {
 });
 ```
 
-If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error.
+If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error. The callback is invoked regardless of the outcome of `shouldSkip`.
 
 ##### shouldRetry(context)
 
 Type: `Function`
 
-Decide if a retry should occur based on the context. Returning true triggers a retry, false aborts with the error.
+Decide if a retry should occur based on the [`RetryContext`](#retrycontext). Returning true triggers a retry, false aborts with the error.
 
 It is only called if `retries` and `maxRetryTime` have not been exhausted.
 
@@ -123,11 +135,11 @@ In the example above, the operation will be retried unless the error is an insta
 
 Type: `Function`
 
-Decide if an error should be "skipped".
+Decide if an error should be skipped.
 
 Skipped errors do not consume retries or impact backoff, but still invoke `onFailedAttempt`.
 
-Receives the same `context` object as `shouldRetry` and `onFailedAttempt`.
+Receives a [`RetryContext`](#retrycontext).
 
 ```js
 import pRetry from 'p-retry';

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,12 @@ Type: `Function`
 
 Callback invoked on each failure. Receives a context object containing the error and retry state information.
 
+The function is called _before_ `shouldConsumeRetry` and `shouldRetry`, for all errors _except_ `AbortError`.
+
+The function is _not_ called on `AbortError`.
+
+If the function throws, all retries will be aborted and the original promise will reject with the thrown error.
+
 ```js
 import pRetry from 'p-retry';
 
@@ -95,21 +101,17 @@ const result = await pRetry(run, {
 });
 ```
 
-If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error.
-
-The callback is invoked regardless of the outcome of other callbacks (e.g `shouldRetry`, `shouldConsumeRetry`).
-
 ##### shouldRetry(context)
 
 Type: `Function`
 
-Decide if a retry should occur based on context. Returning true triggers a retry, false aborts with the error.
+Decide if a retry should occur based on context. Returning `true` triggers a retry, `false` aborts with the error.
 
-It is only called if `retries` and `maxRetryTime` have not been exhausted.
+The function is called _after_ `onFailedAttempt` and `shouldConsumeRetry`.
 
-It is not called for `TypeError` (except network errors) and `AbortError`.
+The function is _not_ called on `AbortError`, `TypeError` (except network errors), or if `retries` or `maxRetryTime` are exhausted.
 
-If the `shouldRetry` function throws, all retries will be aborted and the original promise will reject with the thrown error.
+If the function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
 ```js
 import pRetry from 'p-retry';
@@ -129,7 +131,13 @@ Type: `Function`
 
 Decide if this failure should consume a retry from the `retries` budget.
 
-When `false` is returned, the error does not consume a retry or increment backoff values, but is still subject to `maxRetryTime`.
+When `false` is returned, the failure will not consume a retry or increment backoff values, but is still subject to `maxRetryTime`.
+
+The function is called _after_ `onFailedAttempt`, but before `shouldRetry`.
+
+The function is _not_ called on `AbortError`.
+
+If the function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
 ```js
 import pRetry from 'p-retry';
@@ -143,8 +151,6 @@ const result = await pRetry(run, {
 ```
 
 In the example above, `RateLimitError`s will not decrement the available `retries`.
-
-If the `shouldConsumeRetry` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
 ##### retries
 
@@ -240,7 +246,7 @@ const response = await fetchWithRetry('https://sindresorhus.com/unicorn');
 ### AbortError(message)
 ### AbortError(error)
 
-Abort retrying and reject the promise.
+Abort retrying and reject the promise. No callbacks functions will be called.
 
 ### message
 

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,7 @@ Type: `Function`
 
 Decide if an error should be skipped.
 
-Skipped errors do not consume retries or impact backoff, but still invoke `onFailedAttempt`.
+Skipped errors do not expend retries or increment backoff, but are still subject to `maxRetryTime`.
 
 Receives a [`RetryContext`](#retrycontext).
 

--- a/readme.md
+++ b/readme.md
@@ -47,20 +47,11 @@ Receives the number of attempts as the first argument and is expected to return 
 
 Type: `object`
 
-##### RetryContext
-
-The callbacks below receive a [`RetryContext`](#retrycontext) object describing the current attempt:
-
-- `error`
-- `attemptNumber`
-- `retriesLeft`
-- `retriesUsed`
-
 ##### onFailedAttempt(context)
 
 Type: `Function`
 
-Callback invoked on each failure. Receives a [`RetryContext`](#retrycontext).
+Callback invoked on each failure. Receives a context object containing the error and retry state information.
 
 ```js
 import pRetry from 'p-retry';
@@ -104,17 +95,21 @@ const result = await pRetry(run, {
 });
 ```
 
-If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error. The callback is invoked regardless of the outcome of `shouldSkip`.
+If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error.
+
+The callback is invoked regardless of the outcome of `shouldSkip`.
 
 ##### shouldRetry(context)
 
 Type: `Function`
 
-Decide if a retry should occur based on the [`RetryContext`](#retrycontext). Returning true triggers a retry, false aborts with the error.
+Decide if a retry should occur based on context. Returning true triggers a retry, false aborts with the error.
 
 It is only called if `retries` and `maxRetryTime` have not been exhausted.
 
 It is not called for `TypeError` (except network errors) and `AbortError`.
+
+If the `shouldRetry` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
 ```js
 import pRetry from 'p-retry';
@@ -136,8 +131,6 @@ Decide if an error should be skipped.
 
 Skipped errors do not expend retries or increment backoff, but are still subject to `maxRetryTime`.
 
-Receives a [`RetryContext`](#retrycontext).
-
 ```js
 import pRetry from 'p-retry';
 
@@ -153,6 +146,8 @@ const result = await pRetry(run, {
 ```
 
 In the example above, `RateLimitError`s will not count against the retry limit.
+
+If the `shouldSkip` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
 ##### retries
 

--- a/readme.md
+++ b/readme.md
@@ -55,8 +55,6 @@ Callback invoked on each failure. Receives a context object containing the error
 
 The function is called _before_ `shouldConsumeRetry` and `shouldRetry`, for all errors _except_ `AbortError`.
 
-The function is _not_ called on `AbortError`.
-
 If the function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,8 @@ Default: `1000`
 
 The number of milliseconds before starting the first retry.
 
+Set this to `0` to retry immediately with no delay.
+
 ##### maxTimeout
 
 Type: `number`\
@@ -187,6 +189,8 @@ Type: `number`\
 Default: `Infinity`
 
 The maximum time (in milliseconds) that the retried operation is allowed to run.
+
+Measured with a monotonic clock (`performance.now()`) so system clock adjustments do not affect the limit.
 
 ##### signal
 

--- a/readme.md
+++ b/readme.md
@@ -67,10 +67,10 @@ const run = async () => {
 };
 
 const result = await pRetry(run, {
-	onFailedAttempt: ({error, attemptNumber, retriesLeft, retriesUsed}) => {
-		console.log(`Attempt ${attemptNumber} failed. ${retriesLeft} retries left. ${retriesUsed} retries used.`);
-		// 1st request => Attempt 1 failed. 5 retries left. 0 retries used.
-		// 2nd request => Attempt 2 failed. 4 retries left. 1 retries used.
+	onFailedAttempt: ({error, attemptNumber, retriesLeft, retriesConsumed}) => {
+		console.log(`Attempt ${attemptNumber} failed. ${retriesLeft} retries left. ${retriesConsumed} retries consumed.`);
+		// 1st request => Attempt 1 failed. 5 retries left. 0 retries consumed.
+		// 2nd request => Attempt 2 failed. 4 retries left. 1 retries consumed.
 		// …
 	},
 	retries: 5
@@ -97,7 +97,7 @@ const result = await pRetry(run, {
 
 If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
-The callback is invoked regardless of the outcome of `shouldSkip`.
+The callback is invoked regardless of the outcome of other callbacks (e.g `shouldRetry`, `shouldConsumeRetry`).
 
 ##### shouldRetry(context)
 
@@ -123,13 +123,13 @@ const result = await pRetry(run, {
 
 In the example above, the operation will be retried unless the error is an instance of `CustomError`.
 
-##### shouldSkip(context)
+##### shouldConsumeRetry(context)
 
 Type: `Function`
 
-Decide if an error should be skipped.
+Decide if this failure should consume a retry from the `retries` budget.
 
-Skipped errors do not expend retries or increment backoff, but are still subject to `maxRetryTime`.
+When `false` is returned, the error does not consume a retry or increment backoff values, but is still subject to `maxRetryTime`.
 
 ```js
 import pRetry from 'p-retry';
@@ -138,13 +138,13 @@ const run = async () => { … };
 
 const result = await pRetry(run, {
 	retries: 2,
-	shouldSkip: ({error, retriesLeft}) => error instanceof RateLimitError,
+	shouldConsumeRetry: ({error, retriesLeft}) => !(error instanceof RateLimitError),
 });
 ```
 
-In the example above, `RateLimitError`s will not count against the retry limit.
+In the example above, `RateLimitError`s will not decrement the available `retries`.
 
-If the `shouldSkip` function throws, all retries will be aborted and the original promise will reject with the thrown error.
+If the `shouldConsumeRetry` function throws, all retries will be aborted and the original promise will reject with the thrown error.
 
 ##### retries
 

--- a/readme.md
+++ b/readme.md
@@ -53,11 +53,8 @@ The callbacks below receive a [`RetryContext`](#retrycontext) object describing 
 
 - `error`
 - `attemptNumber`
-- `startTime`:
-- `maxRetryTime`
 - `retriesLeft`
-- `skippedRetries`: number of failures where `shouldSkip` returned `true`.
-- `skip`: whether this attempted will be skipped. Note: this will always `false` within `shouldSkip`, as the outcome has not yet been determined.
+- `retriesUsed`
 
 ##### onFailedAttempt(context)
 
@@ -148,8 +145,8 @@ const run = async () => { … };
 
 const result = await pRetry(run, {
 	retries: 2,
-	shouldSkip: ({error, retriesLeft, skippedRetries}) => {
-		console.log(`Retries left: ${retriesLeft}, skipped so far: ${skippedRetries}`);
+	shouldSkip: ({error, retriesLeft}) => {
+		console.log(`Retries left: ${retriesLeft}`);
 		return error instanceof RateLimitError;
 	},
 });

--- a/test.js
+++ b/test.js
@@ -1033,3 +1033,27 @@ test('retriesLeft is Infinity when retries is Infinity', async t => {
 
 	t.is(observed, Number.POSITIVE_INFINITY);
 });
+
+test('wont count SkipError as attempt', async t => {
+	let attempts = 0;
+	const maxAttempts = 3;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			attempts++;
+
+			if (attempts === maxAttempts) {
+				throw new AbortError('stop');
+			}
+
+			throw new Error('skip');
+		},
+		{
+			retries: 1,
+			shouldSkip: error => error.message === 'skip',
+			minTimeout: 0, // Speed up test
+		},
+	));
+
+	t.is(attempts, maxAttempts);
+});

--- a/test.js
+++ b/test.js
@@ -1050,7 +1050,7 @@ test('wont count SkipError as attempt', async t => {
 		},
 		{
 			retries: 1,
-			shouldSkip: error => error.message === 'skip',
+			shouldSkip: ({error}) => error.message === 'skip',
 			minTimeout: 0, // Speed up test
 		},
 	));

--- a/test.js
+++ b/test.js
@@ -563,7 +563,7 @@ test('callbacks receive expected context data', async t => {
 	const onFailedContexts = [];
 	let attempts = 0;
 
-	const result = await pRetry(async attemptNumber => {
+	const result = await pRetry(async () => {
 		attempts++;
 
 		if (attempts === 1) {
@@ -591,39 +591,39 @@ test('callbacks receive expected context data', async t => {
 	t.is(attempts, 3);
 
 	t.is(shouldSkipContexts.length, 2);
-	const [skipShouldCtx, failShouldCtx] = shouldSkipContexts;
+	const [skipShouldContext, failShouldContext] = shouldSkipContexts;
 
-	t.is(skipShouldCtx.error.message, 'skip');
-	t.is(skipShouldCtx.attemptNumber, 1);
-	t.is(skipShouldCtx.retriesLeft, 2);
-	t.is(skipShouldCtx.skippedRetries, 0);
-	t.false(skipShouldCtx.skip);
+	t.is(skipShouldContext.error.message, 'skip');
+	t.is(skipShouldContext.attemptNumber, 1);
+	t.is(skipShouldContext.retriesLeft, 2);
+	t.is(skipShouldContext.skippedRetries, 0);
+	t.false(skipShouldContext.skip);
 
-	t.is(failShouldCtx.error.message, 'fail');
-	t.is(failShouldCtx.attemptNumber, 2);
-	t.is(failShouldCtx.retriesLeft, 2);
-	t.is(failShouldCtx.skippedRetries, 1);
-	t.false(failShouldCtx.skip);
+	t.is(failShouldContext.error.message, 'fail');
+	t.is(failShouldContext.attemptNumber, 2);
+	t.is(failShouldContext.retriesLeft, 2);
+	t.is(failShouldContext.skippedRetries, 1);
+	t.false(failShouldContext.skip);
 
 	t.is(onFailedContexts.length, 2);
-	const [skipFailedCtx, failFailedCtx] = onFailedContexts;
+	const [skipFailedContext, failFailedContext] = onFailedContexts;
 
-	t.is(skipFailedCtx.error.message, 'skip');
-	t.is(skipFailedCtx.attemptNumber, 1);
-	t.is(skipFailedCtx.retriesLeft, 2);
-	t.is(skipFailedCtx.skippedRetries, 1);
-	t.true(skipFailedCtx.skip);
+	t.is(skipFailedContext.error.message, 'skip');
+	t.is(skipFailedContext.attemptNumber, 1);
+	t.is(skipFailedContext.retriesLeft, 2);
+	t.is(skipFailedContext.skippedRetries, 1);
+	t.true(skipFailedContext.skip);
 
-	t.is(failFailedCtx.error.message, 'fail');
-	t.is(failFailedCtx.attemptNumber, 2);
-	t.is(failFailedCtx.retriesLeft, 2);
-	t.is(failFailedCtx.skippedRetries, 1);
-	t.false(failFailedCtx.skip);
+	t.is(failFailedContext.error.message, 'fail');
+	t.is(failFailedContext.attemptNumber, 2);
+	t.is(failFailedContext.retriesLeft, 2);
+	t.is(failFailedContext.skippedRetries, 1);
+	t.false(failFailedContext.skip);
 
-	t.is(skipShouldCtx.startTime, skipFailedCtx.startTime);
-	t.is(skipShouldCtx.maxRetryTime, skipFailedCtx.maxRetryTime);
-	t.true(Number.isFinite(skipShouldCtx.startTime));
-	t.is(skipShouldCtx.maxRetryTime, Number.POSITIVE_INFINITY);
+	t.is(skipShouldContext.startTime, skipFailedContext.startTime);
+	t.is(skipShouldContext.maxRetryTime, skipFailedContext.maxRetryTime);
+	t.true(Number.isFinite(skipShouldContext.startTime));
+	t.is(skipShouldContext.maxRetryTime, Number.POSITIVE_INFINITY);
 });
 
 test('maxTimeout lower than minTimeout caps delay', async t => {

--- a/test.js
+++ b/test.js
@@ -1147,6 +1147,25 @@ test('retriesLeft is Infinity when retries is Infinity', async t => {
 	t.is(observed.length, maxAttempts);
 });
 
+test('shouldSkip receives normalized error for non-error throws', async t => {
+	let shouldSkipContext;
+
+	await t.throwsAsync(pRetry(async () => {
+		throw 'foo'; // eslint-disable-line no-throw-literal
+	}, {
+		retries: 0,
+		minTimeout: 0,
+		shouldSkip(context) {
+			shouldSkipContext = context;
+			return false;
+		},
+	}), {
+		message: /Non-error/,
+	});
+
+	t.true(shouldSkipContext.error instanceof TypeError);
+});
+
 test('wont count skips as attempt', async t => {
 	let attempts = 0;
 	const maxAttempts = 3;

--- a/test.js
+++ b/test.js
@@ -1034,7 +1034,7 @@ test('retriesLeft is Infinity when retries is Infinity', async t => {
 	t.is(observed, Number.POSITIVE_INFINITY);
 });
 
-test('wont count SkipError as attempt', async t => {
+test('wont count skip as attempt', async t => {
 	let attempts = 0;
 	const maxAttempts = 3;
 
@@ -1049,7 +1049,7 @@ test('wont count SkipError as attempt', async t => {
 			throw new Error('skip');
 		},
 		{
-			retries: 1,
+			retries: 0,
 			shouldSkip: ({error}) => error.message === 'skip',
 			minTimeout: 0, // Speed up test
 		},

--- a/test.js
+++ b/test.js
@@ -406,6 +406,7 @@ test('shouldRetry can be undefined', async t => {
 });
 
 test.serial('factor affects exponential backoff', async t => {
+	// Stronger test: capture actual scheduled delays via mocked setTimeout
 	const captured = [];
 	const originalSetTimeout = setTimeout;
 	globalThis.setTimeout = (function_, ms) => {
@@ -426,6 +427,7 @@ test.serial('factor affects exponential backoff', async t => {
 			factor: 2,
 			minTimeout: 100,
 			maxTimeout: Number.POSITIVE_INFINITY,
+			randomize: false,
 		},
 	));
 

--- a/test.js
+++ b/test.js
@@ -560,72 +560,29 @@ test.serial('skipped attempts do not impact backoff', async t => {
 	t.is(attempts, 5);
 });
 
-test('callbacks receive expected context data', async t => {
-	const shouldSkipContexts = [];
-	const onFailedContexts = [];
+test('shouldSkip time counts toward maxRetryTime', async t => {
 	let attempts = 0;
+	const start = Date.now();
+	const maxRetryTime = 200;
 
-	const result = await pRetry(async () => {
-		attempts++;
-
-		if (attempts === 1) {
-			throw new Error('skip');
-		}
-
-		if (attempts === 2) {
+	const error = await t.throwsAsync(pRetry(
+		async () => {
+			attempts++;
 			throw new Error('fail');
-		}
-
-		return 'ok';
-	}, {
-		retries: 2,
-		minTimeout: 0,
-		shouldSkip(context) {
-			shouldSkipContexts.push(context);
-			return context.error.message === 'skip';
 		},
-		onFailedAttempt(context) {
-			onFailedContexts.push(context);
+		{
+			maxRetryTime,
+			minTimeout: 0,
+			async shouldSkip() {
+				await delay(300);
+				return false;
+			},
 		},
-	});
+	));
 
-	t.is(result, 'ok');
-	t.is(attempts, 3);
-
-	t.is(shouldSkipContexts.length, 2);
-	const [skipShouldContext, failShouldContext] = shouldSkipContexts;
-
-	t.is(skipShouldContext.error.message, 'skip');
-	t.is(skipShouldContext.attemptNumber, 1);
-	t.is(skipShouldContext.retriesLeft, 2);
-	t.is(skipShouldContext.skippedRetries, 0);
-	t.false(skipShouldContext.skip);
-
-	t.is(failShouldContext.error.message, 'fail');
-	t.is(failShouldContext.attemptNumber, 2);
-	t.is(failShouldContext.retriesLeft, 2);
-	t.is(failShouldContext.skippedRetries, 1);
-	t.false(failShouldContext.skip);
-
-	t.is(onFailedContexts.length, 2);
-	const [skipFailedContext, failFailedContext] = onFailedContexts;
-
-	t.is(skipFailedContext.error.message, 'skip');
-	t.is(skipFailedContext.attemptNumber, 1);
-	t.is(skipFailedContext.retriesLeft, 2);
-	t.is(skipFailedContext.skippedRetries, 1);
-	t.true(skipFailedContext.skip);
-
-	t.is(failFailedContext.error.message, 'fail');
-	t.is(failFailedContext.attemptNumber, 2);
-	t.is(failFailedContext.retriesLeft, 2);
-	t.is(failFailedContext.skippedRetries, 1);
-	t.false(failFailedContext.skip);
-
-	t.is(skipShouldContext.startTime, skipFailedContext.startTime);
-	t.is(skipShouldContext.maxRetryTime, skipFailedContext.maxRetryTime);
-	t.true(Number.isFinite(skipShouldContext.startTime));
-	t.is(skipShouldContext.maxRetryTime, Number.POSITIVE_INFINITY);
+	t.is(error.message, 'fail');
+	t.is(attempts, 1);
+	t.true(Date.now() - start < 1000);
 });
 
 test('maxTimeout lower than minTimeout caps delay', async t => {

--- a/test.js
+++ b/test.js
@@ -489,7 +489,7 @@ test.serial('timeouts are incremental with factor', async t => {
 	t.deepEqual(captured, [100, 50, 25]);
 });
 
-test.serial('minTimeout: 0 never calls setTimeout', async t => {
+test.serial('setTimeout is never called with 0 minTimeout', async t => {
 	let called = false;
 	const originalSetTimeout = setTimeout;
 	globalThis.setTimeout = function_ => {
@@ -1213,26 +1213,53 @@ test('shouldConsumeRetry receives normalized error for non-error throws', async 
 	t.true(shouldConsumeRetryContext.error instanceof TypeError);
 });
 
-test('wont count skipped attempts as retries', async t => {
+test.serial('Only consumed retries advance backoff', async t => {
 	let attempts = 0;
-	const maxAttempts = 3;
+	const timeouts = [];
+	const maxAttempts = 4;
+	const minTimeout = 50;
+	const factor = 2;
+	const contexts = [];
+	const originalSetTimeout = setTimeout;
+
+	globalThis.setTimeout = (function_, ms) => {
+		timeouts.push(ms);
+		return originalSetTimeout(function_, 0);
+	};
+
+	t.teardown(() => {
+		globalThis.setTimeout = originalSetTimeout;
+	});
 
 	await t.throwsAsync(pRetry(
 		async () => {
 			attempts++;
 
+			if (attempts === 1) {
+				throw new TypeError('skip');
+			}
+
 			if (attempts === maxAttempts) {
 				throw new AbortError('stop');
 			}
 
-			throw new Error('skip');
+			throw new Error('test');
 		},
 		{
-			retries: 0,
-			shouldConsumeRetry: ({error}) => error.message !== 'skip',
-			minTimeout: 0, // Speed up test
+			retries: 2,
+			onFailedAttempt(context) {
+				contexts.push(context);
+			},
+			shouldConsumeRetry({error}) {
+				return error.message !== 'skip';
+			},
+			factor,
+			minTimeout,
 		},
 	));
 
 	t.is(attempts, maxAttempts);
+	t.deepEqual(contexts.map(context => context.retriesConsumed), [0, 0, 1]);
+	t.deepEqual(contexts.map(context => context.retriesLeft), [2, 2, 1]);
+	t.deepEqual(timeouts, [minTimeout, minTimeout * factor]);
 });

--- a/test.js
+++ b/test.js
@@ -1213,6 +1213,42 @@ test('shouldConsumeRetry receives normalized error for non-error throws', async 
 	t.true(shouldConsumeRetryContext.error instanceof TypeError);
 });
 
+test('shouldConsumeRetry returning false still respects retry budget', async t => {
+	let attempts = 0;
+
+	await t.throwsAsync(pRetry(async () => {
+		attempts++;
+		throw new Error('fail');
+	}, {
+		retries: 0,
+		minTimeout: 0,
+		shouldConsumeRetry: () => false,
+	}), {message: 'fail'});
+
+	t.is(attempts, 1);
+});
+
+test('shouldConsumeRetry returning false still calls shouldRetry', async t => {
+	let attempts = 0;
+	let shouldRetryCalls = 0;
+
+	await t.throwsAsync(pRetry(async () => {
+		attempts++;
+		throw new Error('fail');
+	}, {
+		retries: 3,
+		minTimeout: 0,
+		shouldConsumeRetry: () => false,
+		shouldRetry() {
+			shouldRetryCalls++;
+			return false;
+		},
+	}), {message: 'fail'});
+
+	t.is(attempts, 1);
+	t.is(shouldRetryCalls, 1);
+});
+
 test.serial('Only consumed retries advance backoff', async t => {
 	let attempts = 0;
 	const timeouts = [];
@@ -1258,7 +1294,6 @@ test.serial('Only consumed retries advance backoff', async t => {
 		},
 	));
 
-	t.is(attempts, maxAttempts);
 	t.deepEqual(contexts.map(context => context.retriesConsumed), [0, 0, 1]);
 	t.deepEqual(contexts.map(context => context.retriesLeft), [2, 2, 1]);
 	t.deepEqual(timeouts, [minTimeout, minTimeout * factor]);

--- a/test.js
+++ b/test.js
@@ -178,6 +178,31 @@ test('shouldRetry is not called for AbortError', async t => {
 	t.is(shouldRetryCalled, 0);
 });
 
+test('AbortError short-circuits callbacks', async t => {
+	const originalError = new Error('stop');
+	let attempts = 0;
+
+	const error = await t.throwsAsync(pRetry(async () => {
+		attempts++;
+		throw new AbortError(originalError);
+	}, {
+		onFailedAttempt() {
+			t.fail('onFailedAttempt should not fire');
+		},
+		shouldRetry() {
+			t.fail('shouldRetry should not fire');
+		},
+		shouldConsumeRetry() {
+			t.fail('shouldConsumeRetry should not fire');
+		},
+		retries: 5,
+		minTimeout: 0,
+	}));
+
+	t.is(error, originalError);
+	t.is(attempts, 1);
+});
+
 // AVA does not support DOMException.
 // test('aborts with an AbortSignal', async t => {
 // 	let index = 0;

--- a/test.js
+++ b/test.js
@@ -465,9 +465,9 @@ test.serial('timeouts are incremental with factor', async t => {
 });
 
 test.serial('minTimeout: 0 never calls setTimeout', async t => {
-	const called = false;
+	let called = false;
 	const originalSetTimeout = setTimeout;
-	globalThis.setTimeout = (function_, ms) => {
+	globalThis.setTimeout = function_ => {
 		called = true;
 		return originalSetTimeout(function_, 0);
 	};

--- a/test.js
+++ b/test.js
@@ -550,7 +550,7 @@ test.serial('skipped attempts do not impact backoff', async t => {
 			minTimeout: 100,
 			maxTimeout: Number.POSITIVE_INFINITY,
 			randomize: false,
-			shouldSkip: ({error}) => error.message === 'skip',
+			shouldConsumeRetry: ({error}) => error.message !== 'skip',
 		},
 	));
 
@@ -560,7 +560,7 @@ test.serial('skipped attempts do not impact backoff', async t => {
 	t.is(attempts, 5);
 });
 
-test('shouldSkip time counts toward maxRetryTime', async t => {
+test('shouldConsumeRetry time counts toward maxRetryTime', async t => {
 	let attempts = 0;
 	const start = Date.now();
 	const maxRetryTime = 200;
@@ -573,9 +573,9 @@ test('shouldSkip time counts toward maxRetryTime', async t => {
 		{
 			maxRetryTime,
 			minTimeout: 0,
-			async shouldSkip() {
+			async shouldConsumeRetry() {
 				await delay(300);
-				return false;
+				return true;
 			},
 		},
 	));
@@ -1106,26 +1106,26 @@ test('retriesLeft is Infinity when retries is Infinity', async t => {
 	t.is(observed.length, maxAttempts);
 });
 
-test('shouldSkip receives normalized error for non-error throws', async t => {
-	let shouldSkipContext;
+test('shouldConsumeRetry receives normalized error for non-error throws', async t => {
+	let shouldConsumeRetryContext;
 
 	await t.throwsAsync(pRetry(async () => {
 		throw 'foo'; // eslint-disable-line no-throw-literal
 	}, {
 		retries: 0,
 		minTimeout: 0,
-		shouldSkip(context) {
-			shouldSkipContext = context;
-			return false;
+		shouldConsumeRetry(context) {
+			shouldConsumeRetryContext = context;
+			return true;
 		},
 	}), {
 		message: /Non-error/,
 	});
 
-	t.true(shouldSkipContext.error instanceof TypeError);
+	t.true(shouldConsumeRetryContext.error instanceof TypeError);
 });
 
-test('wont count skips as attempt', async t => {
+test('wont count skipped attempts as retries', async t => {
 	let attempts = 0;
 	const maxAttempts = 3;
 
@@ -1141,7 +1141,7 @@ test('wont count skips as attempt', async t => {
 		},
 		{
 			retries: 0,
-			shouldSkip: ({error}) => error.message === 'skip',
+			shouldConsumeRetry: ({error}) => error.message !== 'skip',
 			minTimeout: 0, // Speed up test
 		},
 	));

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import process from 'node:process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import {performance} from 'node:perf_hooks';
 import {execa} from 'execa';
 import test from 'ava';
 import delay from 'delay';
@@ -461,6 +462,68 @@ test.serial('timeouts are incremental with factor', async t => {
 
 	// With factor 0.5 and minTimeout 100, expected delays: 100, 50, 25 (before rounding)
 	t.deepEqual(captured, [100, 50, 25]);
+});
+
+test.serial('minTimeout: 0 never calls setTimeout', async t => {
+	const called = false;
+	const originalSetTimeout = setTimeout;
+	globalThis.setTimeout = (function_, ms) => {
+		called = true;
+		return originalSetTimeout(function_, 0);
+	};
+
+	t.teardown(() => {
+		globalThis.setTimeout = originalSetTimeout;
+	});
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			throw new Error('test');
+		},
+		{
+			retries: 3,
+			factor: 0.5,
+			minTimeout: 0,
+			maxTimeout: Number.POSITIVE_INFINITY,
+			randomize: false,
+		},
+	));
+
+	t.is(called, false);
+});
+
+test.serial('maxRetryTime uses monotonic clock', async t => {
+	const originalDateNow = Date.now;
+	const originalPerformanceNow = performance.now;
+
+	let simulatedDateNow = 0;
+	Date.now = () => simulatedDateNow;
+
+	let simulatedMonotonicTimestamp = 0;
+	performance.now = () => simulatedMonotonicTimestamp;
+
+	t.teardown(() => {
+		Date.now = originalDateNow;
+		performance.now = originalPerformanceNow;
+	});
+
+	let attempts = 0;
+
+	await t.throwsAsync(pRetry(
+		async () => {
+			attempts++;
+			simulatedMonotonicTimestamp += 60;
+			simulatedDateNow += attempts === 2 ? -1000 : 60;
+			throw new Error('fail');
+		},
+		{
+			maxRetryTime: 100,
+			minTimeout: 0,
+			retries: 5,
+		},
+	), {message: 'fail'});
+
+	t.true(attempts >= 2);
 });
 
 test.serial('minTimeout is respected even with small factor', async t => {


### PR DESCRIPTION
Allows an error to not count against the retry total.

An alternative to https://github.com/sindresorhus/p-retry/pull/94, suggested [here](https://github.com/sindresorhus/p-retry/pull/94#issuecomment-3186009471).